### PR TITLE
.gitignore: added venv dir for puncc-dev-env/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # Virtual environment
 env-puncc/
+puncc-dev-env/
 
 # Local demo files
 **demo/


### PR DESCRIPTION
Makefile creates `puncc-dev-env` virtual environment: makes sense to gitignore it (like older versions)