### PR TITLE
Invalidity check on alpha w.r.t the calibration dataset.

### DIFF
--- a/deel/puncc/api/calibration.py
+++ b/deel/puncc/api/calibration.py
@@ -186,7 +186,8 @@ class BaseCalibrator:
             raise RuntimeError("Run `fit` method before calling `calibrate`.")
 
         # Check consistency of alpha w.r.t the size of calibration data
-        alpha_calib_check(alpha=alpha, n=self._len_calib)
+        if weights is None:
+            alpha_calib_check(alpha=alpha, n=self._len_calib)
 
         # Compute weighted quantiles
         ## Lemma 1 of Tibshirani's paper (https://arxiv.org/pdf/1904.06019.pdf)


### PR DESCRIPTION
Removed the invalidity check on alpha w.r.t the calibration dataset when running weighted conformal regression. In case the number of calibration data points is low w.r.t the significance level, the returned prediction intervals are infinite. 