### PR TITLE
fix: Fixed incorrect pretrained status check in DualPredictor.

### DIFF
--- a/deel/puncc/api/conformalization.py
+++ b/deel/puncc/api/conformalization.py
@@ -280,9 +280,9 @@ class ConformalPredictor:
                 predictor.fit(X_fit, y_fit, **kwargs)  # Fit K-fold predictor
 
             # Make sure that predictor is already trained if train arg is False
-            elif self.train is False and predictor.is_trained is False:
+            elif self.train is False and predictor.get_is_trained() is False:
                 raise RuntimeError(
-                    "'train' argument is set to 'False' but model is not pre-trained"
+                    "'train' argument is set to 'False' but model(s) not pre-trained."
                 )
 
             else:  # Skipping training

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ copyright = (
 author = "Mouhcine Mendil, Luca Mossina and Joseba Dalmau"
 
 # The full version, including alpha/beta/rc tags
-release = "0.7.4"
+release = "0.7.6"
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ joblib
 matplotlib
 numpy
 pandas
-scikit-learn
+scikit-learn~=1.3.0
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ dev_requirements = [
 
 setuptools.setup(
     name="puncc",
-    version="0.7.5",
+    version="0.7.6",
     author=", ".join(["Mouhcine Mendil", "Luca Mossina", "Joseba Dalmau"]),
     author_email=", ".join(
         [


### PR DESCRIPTION
- Changed `pkgutil.find_loader` with `importlib.util.find_spec` as `find_loader` is deprecated and will be removed in python 3.14.
- Fixed incorrect check of pretrained status in DualPredictor (and MeanVarPredictor). Wrapped models need to have their `is_trained` status set to True to consider that DualPredictor (or MeanVarPredictor) is pretrained.