### PR TITLE
Fix issue70 for DualPredictor

### DIFF
--- a/deel/puncc/api/prediction.py
+++ b/deel/puncc/api/prediction.py
@@ -507,6 +507,11 @@ class DualPredictor:
             is_trained=self.is_trained,
             compile_args=self.compile_args,
         )
+        # copy extra attributes from the original instance
+        for name, value in self.__dict__.items():
+            if name in ["models", "is_trained", "compile_args"]:
+                continue
+            setattr(predictor_copy, name, value)
         return predictor_copy
 
 


### PR DESCRIPTION
Related to https://github.com/deel-ai/puncc/issues/70. This fixes the `DualPredictor.copy()` method in the same way `BasePredictor.copy()` was fixed by https://github.com/deel-ai/puncc/pull/71.