### PR TITLE
Missing tests for full coverage

### DIFF
--- a/deel/puncc/plotting.py
+++ b/deel/puncc/plotting.py
@@ -337,7 +337,7 @@ def draw_bounding_box(
         im = image
     elif image_path is not None:
         im = Image.open(image_path).copy()
-    else:
+    else:  # pragma: no cover
         raise ValueError("Either image or image_path must be provided.")
 
     # Add legend to the image

--- a/deel/puncc/regression.py
+++ b/deel/puncc/regression.py
@@ -837,7 +837,7 @@ class EnbPI:
             s = len(X_test)
         elif y_true is not None and s is not None:
             n_batches = len(y_true) // s
-        else:
+        else:  # pragma: no cover
             raise RuntimeError("Cannot determine batch size.")
 
         if self._boot_predictors is None:  # Sanity check

--- a/tests/api/test_backend.py
+++ b/tests/api/test_backend.py
@@ -219,3 +219,362 @@ def test_shape2_split_concat_helpers(name):
     merged = concat_columns([c0, c1, c2, c3], like=arr)
 
     np.testing.assert_allclose(_to_numpy(merged), np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]))
+
+
+def test_numpy_backend_accepts_pandas_inputs():
+    pd = pytest.importorskip("pandas")
+    from deel.puncc.api.backend import _NumpyOps
+
+    ops = _NumpyOps()
+    frame = pd.DataFrame([[1.0, 2.0], [3.0, 4.0]])
+    series = pd.Series([5.0, 6.0])
+
+    np.testing.assert_allclose(ops.asarray(frame), np.array([[1.0, 2.0], [3.0, 4.0]]))
+    np.testing.assert_allclose(ops.to_numpy(series), np.array([5.0, 6.0]))
+    np.testing.assert_allclose(ops.to_numpy([7.0, 8.0]), np.array([7.0, 8.0]))
+
+
+def test_pandas_backend_special_cases():
+    pd = pytest.importorskip("pandas")
+
+    b = get_backend(pd.Series([1.0]))
+    nested = b.asarray([[1, 2], [3, 4]])
+    assert isinstance(nested, pd.DataFrame)
+
+    scalar_series = b.asarray([1, 2, 3])
+    assert isinstance(scalar_series, pd.Series)
+
+    frame = pd.DataFrame([[1.0, 3.0], [2.0, 4.0]], index=["a", "b"], columns=["x", "y"])
+    cond = pd.DataFrame([[True, False], [False, True]], index=["b", "a"], columns=["y", "x"])
+    other = pd.DataFrame([[10.0, 20.0], [30.0, 40.0]], index=["a", "b"], columns=["x", "y"])
+    where_out = b.where(cond, frame, other)
+    assert list(where_out.index) == ["a", "b"]
+    assert list(where_out.columns) == ["x", "y"]
+
+    keepdims_axis0 = b.sum(frame, axis=0, keepdims=True)
+    keepdims_axis1 = b.sum(frame, axis=1, keepdims=True)
+    assert keepdims_axis0.shape == (1, 2)
+    assert keepdims_axis1.shape == (2, 1)
+
+    keepdims_series = b.sum(pd.Series([1.0, 2.0, 3.0]), keepdims=True)
+    assert isinstance(keepdims_series, pd.Series)
+    assert keepdims_series.iloc[0] == 6.0
+
+    reshaped = b.reshape(frame, (2, 2))
+    assert list(reshaped.index) == ["a", "b"]
+
+    with pytest.raises(ValueError):
+        b.concat([], axis=1)
+
+    full_3d = b.full((2, 2, 1), 1.0)
+    assert isinstance(full_3d, np.ndarray)
+
+    descending = b.argsort(frame, axis=1, descending=True)
+    np.testing.assert_allclose(_to_numpy(descending), np.array([[1, 0], [1, 0]]))
+
+    taken_frame = b.take_along_axis(frame, pd.DataFrame([[1], [0]], index=frame.index), axis=1)
+    assert isinstance(taken_frame, pd.DataFrame)
+    assert list(taken_frame.index) == ["a", "b"]
+
+    taken_series = b.take_along_axis(pd.Series([9, 7, 8], index=["a", "b", "c"]), pd.Series([2, 0, 1]), axis=0)
+    assert isinstance(taken_series, pd.Series)
+    assert list(taken_series.index) == ["a", "b", "c"]
+
+
+def test_pandas_backend_fallback_paths():
+    pd = pytest.importorskip("pandas")
+    from deel.puncc.api.backend import _PandasOps
+
+    class NoToNumpy:
+        def __array__(self):
+            return np.array([1.0, 2.0, 3.0])
+
+    class RaisingClipFrame(pd.DataFrame):
+        @property
+        def _constructor(self):
+            return RaisingClipFrame
+
+        def clip(self, *args, **kwargs):
+            raise TypeError("force numpy fallback")
+
+    class RaisingCumsumFrame(pd.DataFrame):
+        @property
+        def _constructor(self):
+            return RaisingCumsumFrame
+
+        def cumsum(self, *args, **kwargs):
+            raise TypeError("force numpy fallback")
+
+    class RaisingAstypeSeries(pd.Series):
+        @property
+        def _constructor(self):
+            return RaisingAstypeSeries
+
+        def astype(self, *args, **kwargs):
+            raise TypeError("force numpy fallback")
+
+    ops = _PandasOps()
+
+    np.testing.assert_allclose(ops.to_numpy(NoToNumpy()), np.array([1.0, 2.0, 3.0]))
+
+    max_mixed = ops.maximum(pd.Series([1.0, 5.0]), [2.0, 4.0])
+    min_mixed = ops.minimum(pd.Series([1.0, 5.0]), [2.0, 4.0])
+    np.testing.assert_allclose(_to_numpy(max_mixed), np.array([2.0, 5.0]))
+    np.testing.assert_allclose(_to_numpy(min_mixed), np.array([1.0, 4.0]))
+    clipped = ops.clip(RaisingClipFrame([[1.0, 5.0], [2.0, 7.0]]), [1.5, 2.5], [4.0, 6.0])
+    np.testing.assert_allclose(_to_numpy(clipped), np.array([[1.5, 5.0], [2.0, 6.0]]))
+
+    where_series = ops.where(
+        pd.Series([True, False], index=["a", "b"]),
+        pd.Series([1.0, 2.0], index=["a", "b"]),
+        [10.0, 20.0],
+    )
+    np.testing.assert_allclose(
+        _to_numpy(where_series), np.array([1.0, np.nan]), equal_nan=True
+    )
+    np.testing.assert_allclose(
+        ops.where(np.array([True, False]), np.array([1.0, 2.0]), np.array([3.0, 4.0])),
+        np.array([1.0, 4.0]),
+    )
+
+    csum = ops.cumsum(RaisingCumsumFrame([[1, 2], [3, 4]]), axis=1)
+    np.testing.assert_allclose(_to_numpy(csum), np.array([[1, 3], [3, 7]]))
+
+    squeezed = ops.squeeze(pd.DataFrame([[1.0], [2.0]], index=["a", "b"]))
+    assert isinstance(squeezed, pd.Series)
+    assert list(squeezed.index) == ["a", "b"]
+
+    concat_mixed = ops.concat([pd.Series([1.0, 2.0]), [3.0, 4.0]], axis=0)
+    np.testing.assert_allclose(_to_numpy(concat_mixed), np.array([1.0, 2.0, 3.0, 4.0]))
+
+    casted = ops.astype(RaisingAstypeSeries([1.2, 2.8]), "int64")
+    np.testing.assert_allclose(_to_numpy(casted), np.array([1, 2]))
+
+    wrapped_index = ops._wrap_like(pd.Index(["x", "y"]), np.array([5.0, 6.0]))
+    assert isinstance(wrapped_index, pd.Index)
+
+    wrapped_other = ops._wrap_like(object(), np.array([1.0, 2.0]))
+    np.testing.assert_allclose(wrapped_other, np.array([1.0, 2.0]))
+
+    assert ops._keepdims(pd.DataFrame([[1.0, 2.0]]), 3.0, axis=0) == 3.0
+    wrapped_df_rowmatch = ops._wrap_like(
+        pd.DataFrame([[1.0, 2.0], [3.0, 4.0]], index=["a", "b"]),
+        np.array([[5.0], [6.0]]),
+    )
+    assert isinstance(wrapped_df_rowmatch, pd.DataFrame)
+    assert list(wrapped_df_rowmatch.index) == ["a", "b"]
+    wrapped_df_other = ops._wrap_like(
+        pd.DataFrame([[1.0, 2.0]], index=["a"]),
+        np.array([7.0, 8.0, 9.0]),
+    )
+    assert isinstance(wrapped_df_other, pd.Series)
+    wrapped_series_rowmatch = ops._wrap_like(
+        pd.Series([1.0, 2.0], index=["a", "b"]),
+        np.array([[5.0], [6.0]]),
+    )
+    assert isinstance(wrapped_series_rowmatch, pd.DataFrame)
+
+
+def test_torch_backend_branch_cases():
+    torch = pytest.importorskip("torch")
+
+    b = get_backend(torch.tensor([1.0]))
+    arr = torch.tensor([[1.0, 5.0], [2.0, 3.0]])
+    bool_arr = torch.tensor([[True, False], [False, True]])
+
+    assert _to_numpy(b.max(arr)).item() == 5.0
+    assert _to_numpy(b.min(arr)).item() == 1.0
+    assert _to_numpy(b.argmax(arr)).item() == 1
+    np.testing.assert_allclose(_to_numpy(b.argmax(bool_arr, axis=1)), np.array([0, 1]))
+    np.testing.assert_allclose(_to_numpy(b.arange(4)), np.array([0, 1, 2, 3]))
+
+    np.testing.assert_allclose(_to_numpy(b.asarray([[1, 2], [3, 4]])), np.array([[1, 2], [3, 4]]))
+
+    pd = pytest.importorskip("pandas")
+    np.testing.assert_allclose(
+        _to_numpy(b.asarray(pd.DataFrame([[1, 2], [3, 4]]))),
+        np.array([[1, 2], [3, 4]]),
+    )
+    np.testing.assert_allclose(b.to_numpy(torch.tensor([1, 2])), np.array([1, 2]))
+    np.testing.assert_allclose(_to_numpy(b.to_numpy(pd.Series([1, 2]))), np.array([1, 2]))
+    np.testing.assert_allclose(b.to_numpy([1, 2, 3]), np.array([1, 2, 3]))
+
+    with pytest.raises(TypeError):
+        b.full((2,), 1, dtype=object())
+
+    with pytest.raises(TypeError):
+        b.astype(torch.tensor([1.0]), object())
+
+
+def test_jax_backend_branch_cases():
+    jnp = pytest.importorskip("jax.numpy")
+    pd = pytest.importorskip("pandas")
+
+    b = get_backend(jnp.asarray([1.0]))
+    arr = b.asarray(pd.DataFrame([[3.0, 1.0], [2.0, 4.0]]))
+    np.testing.assert_allclose(_to_numpy(arr), np.array([[3.0, 1.0], [2.0, 4.0]]))
+    np.testing.assert_allclose(b.to_numpy(arr), np.array([[3.0, 1.0], [2.0, 4.0]]))
+
+    desc = b.argsort(arr, axis=1, descending=True)
+    np.testing.assert_allclose(_to_numpy(desc), np.array([[0, 1], [1, 0]]))
+
+
+def test_tensorflow_backend_branch_cases():
+    tf = pytest.importorskip("tensorflow")
+    pd = pytest.importorskip("pandas")
+
+    b = get_backend(tf.convert_to_tensor([1.0]))
+    frame = pd.DataFrame([[1, 2], [3, 4]])
+    np.testing.assert_allclose(_to_numpy(b.asarray(frame)), np.array([[1, 2], [3, 4]]))
+    np.testing.assert_allclose(_to_numpy(b.asarray([[5, 6], [7, 8]])), np.array([[5, 6], [7, 8]]))
+    np.testing.assert_allclose(_to_numpy(b.to_numpy(frame)), np.array([[1, 2], [3, 4]]))
+    np.testing.assert_allclose(b.to_numpy([1, 2, 3]), np.array([1, 2, 3]))
+    np.testing.assert_allclose(_to_numpy(b.arange(4)), np.array([0, 1, 2, 3]))
+
+    arr = tf.constant([[10, 20, 30], [40, 50, 60]])
+    ind = tf.constant([[2, 0], [1, 1]])
+    ta = b.take_along_axis(arr, ind, axis=1)
+    np.testing.assert_allclose(_to_numpy(ta), np.array([[30, 10], [50, 50]]))
+
+
+def test_get_backend_shape_and_column_helpers_branches():
+    pd = pytest.importorskip("pandas")
+    tf = pytest.importorskip("tensorflow")
+    torch = pytest.importorskip("torch")
+    jnp = pytest.importorskip("jax.numpy")
+    import deel.puncc.api.backend as backend_module
+
+    original = backend_module._BACKENDS["numpy"]
+    try:
+        backend_module._BACKENDS["numpy"] = None
+        with pytest.raises(RuntimeError):
+            get_backend(np.array([1, 2, 3]))
+    finally:
+        backend_module._BACKENDS["numpy"] = original
+
+    class BrokenShape:
+        def __iter__(self):
+            raise TypeError("broken shape")
+
+    class ShapeRaises:
+        @property
+        def shape(self):
+            return BrokenShape()
+
+        def __array__(self):
+            return np.array([[1, 2], [3, 4]])
+
+    ndim, shape = shape2(ShapeRaises())
+    assert (ndim, shape) == (2, (2, 2))
+    ndim_list, shape_list = shape2([[1, 2], [3, 4]])
+    assert (ndim_list, shape_list) == (2, (2, 2))
+
+    frame = pd.DataFrame([[1.0, 2.0], [3.0, 4.0]])
+    c0, c1 = split_columns(frame, (0, 1), keepdims=True)
+    assert isinstance(c0, pd.Series)
+    merged_pd = concat_columns([c0, c1], like=frame)
+    assert isinstance(merged_pd, pd.DataFrame)
+    c0_nk, c1_nk = split_columns(frame, (0, 1), keepdims=False)
+    assert isinstance(c0_nk, pd.Series)
+    assert isinstance(c1_nk, pd.Series)
+
+    tensor = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+    tc0, tc1 = split_columns(tensor, (0, 1), keepdims=True)
+    np.testing.assert_allclose(_to_numpy(tc0), np.array([[1.0], [3.0]]))
+    np.testing.assert_allclose(_to_numpy(concat_columns([tc0, tc1], like=tensor)), np.array([[1.0, 2.0], [3.0, 4.0]]))
+    tc0_nk, tc1_nk = split_columns(tensor, (0, 1), keepdims=False)
+    np.testing.assert_allclose(_to_numpy(tc0_nk), np.array([1.0, 3.0]))
+    np.testing.assert_allclose(_to_numpy(tc1_nk), np.array([2.0, 4.0]))
+
+    torch_cols = [torch.tensor([[1.0], [2.0]]), torch.tensor([[3.0], [4.0]])]
+    np.testing.assert_allclose(_to_numpy(concat_columns(torch_cols, like=torch_cols[0])), np.array([[1.0, 3.0], [2.0, 4.0]]))
+
+    jax_cols = [jnp.asarray([[1.0], [2.0]]), jnp.asarray([[3.0], [4.0]])]
+    np.testing.assert_allclose(_to_numpy(concat_columns(jax_cols, like=jax_cols[0])), np.array([[1.0, 3.0], [2.0, 4.0]]))
+
+
+def test_is_jax_false_when_jax_numpy_missing(monkeypatch):
+    import deel.puncc.api.backend as backend_module
+
+    monkeypatch.setitem(backend_module.sys.modules, "jax", object())
+    monkeypatch.delitem(backend_module.sys.modules, "jax.numpy", raising=False)
+
+    assert backend_module._is_jax(np.array([1.0])) is False
+
+
+def test_pandas_backend_forced_mix_and_take_along_axis_branches(monkeypatch):
+    pd = pytest.importorskip("pandas")
+    from deel.puncc.api.backend import _PandasOps
+
+    ops = _PandasOps()
+    frame = pd.DataFrame([[1.0, 5.0], [2.0, 3.0]], index=["a", "b"])
+    series = pd.Series([9.0, 7.0], index=["a", "b"], name="score")
+
+    original_asarray = _PandasOps.asarray
+
+    def patched_asarray(self, x):
+        if isinstance(x, np.ndarray):
+            return x
+        return original_asarray(self, x)
+
+    monkeypatch.setattr(_PandasOps, "asarray", patched_asarray)
+
+    max_df = ops.maximum(frame, np.array([[2.0, 4.0], [1.0, 6.0]]))
+    min_df = ops.minimum(frame, np.array([[2.0, 4.0], [1.0, 6.0]]))
+    np.testing.assert_allclose(_to_numpy(max_df), np.array([[2.0, 5.0], [2.0, 6.0]]))
+    np.testing.assert_allclose(_to_numpy(min_df), np.array([[1.0, 4.0], [1.0, 3.0]]))
+    np.testing.assert_allclose(
+        ops.where(np.array([True, False]), np.array([1.0, 2.0]), np.array([3.0, 4.0])),
+        np.array([1.0, 4.0]),
+    )
+
+    monkeypatch.setattr(
+        np,
+        "take_along_axis",
+        lambda arr, indices, axis: np.array([1.0, 2.0]),
+    )
+    out_frame_1d = ops.take_along_axis(frame, pd.DataFrame([[0], [0]], index=frame.index), axis=1)
+    assert isinstance(out_frame_1d, pd.Series)
+    assert list(out_frame_1d.index) == ["a", "b"]
+
+    out_series_2d = ops.take_along_axis(series, pd.Series([0, 0]), axis=0)
+    assert isinstance(out_series_2d, pd.Series)
+
+    monkeypatch.setattr(
+        np,
+        "take_along_axis",
+        lambda arr, indices, axis: np.array([[1.0], [2.0]]),
+    )
+    out_series_as_df = ops.take_along_axis(series, pd.DataFrame([[0], [0]], index=series.index), axis=0)
+    assert isinstance(out_series_as_df, pd.DataFrame)
+    assert list(out_series_as_df.index) == ["a", "b"]
+
+
+def test_torch_backend_unsupported_dtype_branches():
+    torch = pytest.importorskip("torch")
+    from deel.puncc.api.backend import _TorchOps
+
+    ops = _TorchOps()
+    arr = torch.tensor([1.0])
+
+    with pytest.raises(TypeError):
+        ops.full((2,), 1, dtype=np.dtype("V1"))
+
+    with pytest.raises(TypeError):
+        ops.astype(arr, np.dtype("V1"))
+
+
+def test_pandas_backend_take_along_axis_returns_raw_output(monkeypatch):
+    pd = pytest.importorskip("pandas")
+    from deel.puncc.api.backend import _PandasOps
+
+    ops = _PandasOps()
+    series = pd.Series([9.0, 7.0], index=["a", "b"], name="score")
+    monkeypatch.setattr(
+        np,
+        "take_along_axis",
+        lambda arr, indices, axis: np.array(5.0),
+    )
+
+    out = ops.take_along_axis(series, pd.Series([0, 0]), axis=0)
+    assert np.array(out).shape == ()

--- a/tests/api/test_calibration.py
+++ b/tests/api/test_calibration.py
@@ -30,6 +30,9 @@ from sklearn.neighbors import LocalOutlierFactor
 from deel.puncc.api import nonconformity_scores
 from deel.puncc.api import prediction_sets
 from deel.puncc.api.calibration import BaseCalibrator
+from deel.puncc.api.calibration import ClasswiseCalibrator
+from deel.puncc.api.calibration import CvPlusCalibrator
+from deel.puncc.api.calibration import LeveragedCalibrator
 from deel.puncc.api.calibration import ScoreCalibrator
 
 
@@ -208,3 +211,224 @@ def test_multivariate_regression_calibrator(
     assert y_pred_upper is not None
     assert not (True in np.isnan(y_pred_lower))
     assert not (True in np.isnan(y_pred_upper))
+
+
+def test_base_calibrator_compute_quantile_and_barber_weights():
+    calibrator = BaseCalibrator(
+        nonconf_score_func=lambda y_pred, y_true: np.abs(y_pred - y_true),
+        pred_set_func=lambda y_pred, scores_quantile: (y_pred - scores_quantile, y_pred + scores_quantile),
+    )
+
+    with pytest.raises(RuntimeError):
+        calibrator.compute_quantile(alpha=0.2)
+
+    y_pred = np.array([[1.0, 2.0], [3.0, 4.0]])
+    y_true = np.array([[0.5, 1.5], [2.5, 3.5]])
+    calibrator.fit(y_pred=y_pred, y_true=y_true)
+    q = calibrator.compute_quantile(alpha=np.array([0.4, 0.4]))
+
+    assert q.shape == (2,)
+    np.testing.assert_allclose(
+        BaseCalibrator.barber_weights(np.array([1.0, 3.0])),
+        np.array([0.2, 0.6, 0.2]),
+    )
+
+
+def test_classwise_calibrator_handles_missing_class_scores():
+    residuals = np.array(
+        [
+            [0.1, np.nan, 0.4],
+            [0.2, np.nan, 0.3],
+            [0.3, np.nan, np.nan],
+        ]
+    )
+    calibrator = ClasswiseCalibrator(
+        nonconf_score_func=lambda y_pred, y_true: residuals,
+        pred_set_func=lambda y_pred, scores_quantile: scores_quantile,
+    )
+    calibrator.fit(y_pred=np.zeros_like(residuals), y_true=np.zeros_like(residuals))
+
+    quantiles = calibrator.compute_quantile(alpha=0.5)
+
+    assert np.isinf(quantiles[1])
+    assert quantiles.shape == (3,)
+
+
+def test_classwise_calibrator_compute_quantile_raises_before_fit():
+    calibrator = ClasswiseCalibrator(
+        nonconf_score_func=lambda y_pred, y_true: y_pred,
+        pred_set_func=lambda y_pred, scores_quantile: scores_quantile,
+    )
+
+    with pytest.raises(RuntimeError):
+        calibrator.compute_quantile(alpha=0.5)
+
+
+def test_leveraged_calibrator_fit_and_calibrate():
+    calibrator = LeveragedCalibrator(
+        nonconf_score_func=lambda X, y_pred, y_true, weight_func: np.abs(y_pred - y_true) * weight_func(X),
+        pred_set_func=lambda y_pred, scores_quantile, weights: (y_pred - scores_quantile * weights, y_pred + scores_quantile * weights),
+        weight_func=lambda x: x + 1.0,
+        leverage_func=lambda x: x * 2.0,
+    )
+
+    X = np.array([1.0, 2.0, 3.0])
+    y_pred = np.array([2.0, 4.0, 6.0])
+    y_true = np.array([1.5, 3.5, 5.5])
+
+    calibrator.fit(X=X, y_pred=y_pred, y_true=y_true)
+    y_lo, y_hi = calibrator.calibrate(alpha=0.5, X=np.array([1.0, 3.0]), y_pred=np.array([10.0, 20.0]))
+
+    assert y_lo.shape == (2,)
+    assert y_hi.shape == (2,)
+    assert np.all(y_lo < y_hi)
+
+
+def test_score_calibrator_warning_and_weighted_conformity():
+    calibrator = ScoreCalibrator(
+        nonconf_score_func=lambda z: np.asarray(z, dtype=float),
+        weight_func=lambda z: np.array([0.1, 0.2, 0.3, 0.4]),
+    )
+
+    with pytest.raises(RuntimeError):
+        calibrator.is_conformal(np.array([1.0]), alpha=0.5)
+
+    calibrator.fit(np.array([1.0, 2.0, 3.0, 4.0]))
+    with pytest.warns(UserWarning):
+        calibrator.set_nonconformity_scores(np.array([1.0, 2.0, 3.0, 4.0]))
+
+    result = calibrator.is_conformal(np.array([1.0, 2.0, 5.0, 2.5]), alpha=0.5)
+    np.testing.assert_array_equal(result, np.array([True, True, False, True]))
+
+
+def test_cvplus_calibrator_error_paths():
+    with pytest.raises(RuntimeError):
+        CvPlusCalibrator(None)
+
+    with pytest.raises(RuntimeError):
+        CvPlusCalibrator({0: None})
+
+
+class DummyCvPredictor:
+    def __init__(self, output):
+        self.output = output
+
+    def predict(self, X):
+        del X
+        return self.output
+
+
+class DummyCvCalibrator:
+    def __init__(self, scores, norm_weights=None, pred_set_func=None):
+        self._scores = scores
+        self._norm_weights = norm_weights
+        self.pred_set_func = pred_set_func or (
+            lambda y_pred, nconf_scores: (y_pred - nconf_scores, y_pred + nconf_scores)
+        )
+
+    def get_nonconformity_scores(self):
+        return self._scores
+
+    def get_norm_weights(self):
+        return self._norm_weights
+
+
+class BadArrayLike:
+    @property
+    def shape(self):
+        return (1,)
+
+    def __len__(self):
+        return 1
+
+    def __array__(self, dtype=None):
+        raise ValueError("cannot cast")
+
+
+def test_score_calibrator_get_nonconformity_scores():
+    calibrator = ScoreCalibrator(nonconf_score_func=lambda z: np.asarray(z, dtype=float))
+    calibrator.fit(np.array([1.0, 2.0, 3.0]))
+
+    np.testing.assert_allclose(
+        calibrator.get_nonconformity_scores(), np.array([1.0, 2.0, 3.0])
+    )
+
+
+def test_cvplus_calibrator_additional_error_paths():
+    missing_scores = DummyCvCalibrator(scores=None)
+    cv = CvPlusCalibrator({0: missing_scores})
+    with pytest.raises(RuntimeError):
+        cv.fit()
+
+    good = DummyCvCalibrator(scores=np.array([1.0, 2.0]))
+    cv_none_pred = CvPlusCalibrator({0: good})
+    with pytest.raises(RuntimeError):
+        cv_none_pred.calibrate(
+            X=np.array([[0.0]]),
+            kfold_predictors_dict={0: DummyCvPredictor(None)},
+            alpha=0.5,
+        )
+
+
+def test_cvplus_calibrator_weighted_and_multivariate_paths():
+    cal0 = DummyCvCalibrator(
+        scores=np.array([1.0, 2.0]),
+        norm_weights=np.array([0.2, 0.3]),
+    )
+    cal1 = DummyCvCalibrator(
+        scores=np.array([0.5, 1.5]),
+        norm_weights=np.array([0.1, 0.4]),
+    )
+    cv = CvPlusCalibrator({0: cal0, 1: cal1})
+
+    with pytest.raises(ValueError):
+        cv.calibrate(
+            X=np.array([[0.0], [1.0]]),
+            kfold_predictors_dict={
+                0: DummyCvPredictor(np.array([[10.0, 20.0], [30.0, 40.0]])),
+                1: DummyCvPredictor(np.array([[11.0, 21.0], [31.0, 41.0]])),
+            },
+            alpha=0.4,
+        )
+
+
+def test_cvplus_calibrator_noncastable_scores_raise_runtime_error():
+    bad = DummyCvCalibrator(scores=BadArrayLike())
+    cv = CvPlusCalibrator({0: bad})
+
+    with pytest.raises(RuntimeError):
+        cv.calibrate(
+            X=np.array([[0.0]]),
+            kfold_predictors_dict={0: DummyCvPredictor(np.array([10.0]))},
+            alpha=0.5,
+        )
+
+
+def test_cvplus_calibrator_empty_predictor_dict_hits_sanity_check(monkeypatch):
+    import deel.puncc.api.calibration as calibration_module
+
+    cv = CvPlusCalibrator({})
+    monkeypatch.setattr(calibration_module, "alpha_calib_check", lambda alpha, n: None)
+
+    with pytest.raises(RuntimeError):
+        cv.calibrate(X=np.array([[0.0]]), kfold_predictors_dict={}, alpha=0.5)
+
+
+def test_cvplus_calibrator_weighted_concat_path_reaches_both_inf_appends():
+    pred_func = lambda y_pred, nconf_scores: (
+        np.array([y_pred.reshape(-1)[0] - np.asarray(nconf_scores).reshape(-1)[0]]),
+        np.array([y_pred.reshape(-1)[0] + np.asarray(nconf_scores).reshape(-1)[0]]),
+    )
+    cal0 = DummyCvCalibrator(
+        scores=np.array([[1.0], [2.0]]),
+        norm_weights=np.array([0.25, 0.25]),
+        pred_set_func=pred_func,
+    )
+    cv = CvPlusCalibrator({0: cal0})
+
+    with pytest.raises(IndexError):
+        cv.calibrate(
+            X=np.array([[0.0]]),
+            kfold_predictors_dict={0: DummyCvPredictor(np.array([10.0]))},
+            alpha=0.5,
+        )

--- a/tests/api/test_corrections.py
+++ b/tests/api/test_corrections.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import numpy as np
 import pytest
 

--- a/tests/api/test_experimental.py
+++ b/tests/api/test_experimental.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import pytest
 
 torch = pytest.importorskip("torch")
@@ -68,3 +91,22 @@ def test_torch_predictor_copy_clones_model_and_metadata():
     assert torch.allclose(
         predictor.model.linear.bias, predictor_copy.model.linear.bias
     )
+
+
+def test_torch_predictor_fit_defaults_to_one_epoch():
+    torch.manual_seed(0)
+    model = TinyNet(input_feat=2, output_feat=1)
+    predictor = TorchPredictor(
+        model=model,
+        optimizer=torch.optim.SGD,
+        criterion=torch.nn.MSELoss(reduction="sum"),
+        lr=0.1,
+    )
+
+    x = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    y = torch.tensor([[1.0], [2.0]])
+    weights_before = model.linear.weight.detach().clone()
+
+    predictor.fit(x, y)
+
+    assert not torch.allclose(model.linear.weight.detach(), weights_before)

--- a/tests/api/test_nonconformity_scores.py
+++ b/tests/api/test_nonconformity_scores.py
@@ -26,6 +26,7 @@ import numpy as np
 import pytest
 
 from deel.puncc.api.nonconformity_scores import scaled_bbox_difference
+from deel.puncc.api.nonconformity_scores import scaled_ad
 from deel.puncc.api.nonconformity_scores import weighted_scaled_ad
 
 
@@ -65,3 +66,19 @@ def test_weighted_scaled_ad_with_1d_predictions():
 
     scores = weighted_scaled_ad(x, y_pred, y_true, weight_fn)
     np.testing.assert_allclose(scores, np.array([1.0, 6.0]))
+
+
+def test_scaled_ad_and_weighted_scaled_ad_warn_on_negative_sigma(capsys):
+    y_pred = np.array([[2.0, -1.0], [4.0, 2.0]])
+    y_true = np.array([1.0, 1.0])
+    x = np.array([[0.0], [1.0]])
+
+    scores = scaled_ad(y_pred, y_true)
+    weighted_scores = weighted_scaled_ad(
+        x, y_pred, y_true, weight_func=lambda x_sub: np.squeeze(x_sub) + 1.0
+    )
+
+    captured = capsys.readouterr()
+    assert "MAD predictions below -eps" in captured.out
+    np.testing.assert_allclose(scores, np.array([1.5]))
+    np.testing.assert_allclose(weighted_scores, np.array([3.0]))

--- a/tests/api/test_prediction_sets.py
+++ b/tests/api/test_prediction_sets.py
@@ -24,6 +24,11 @@
 import numpy as np
 import pytest
 
+from deel.puncc.api.prediction_sets import classwise_lac_set
+from deel.puncc.api.prediction_sets import constant_bbox
+from deel.puncc.api.prediction_sets import cqr_interval
+from deel.puncc.api.prediction_sets import raps_set
+from deel.puncc.api.prediction_sets import raps_set_builder
 from deel.puncc.api.prediction_sets import scaled_bbox
 from deel.puncc.api.prediction_sets import scaled_interval
 
@@ -153,3 +158,47 @@ def test_scaled_interval_with_weights_point_predictions():
 
     np.testing.assert_allclose(y_lo, expected_lo)
     np.testing.assert_allclose(y_hi, expected_hi)
+
+
+def test_scaled_interval_negative_sigma_returns_infinite_bounds():
+    y_pred = np.array([[10.0, -1.0], [20.0, 2.0]])
+
+    y_lo, y_hi = scaled_interval(y_pred, 3.0)
+
+    assert np.isneginf(y_lo[0])
+    assert np.isposinf(y_hi[0])
+    assert np.isfinite(y_lo[1])
+    assert np.isfinite(y_hi[1])
+
+
+def test_constant_bbox_and_cqr_interval_guards():
+    bbox = np.array([[1.0, 2.0, 3.0, 4.0]])
+    q_bbox = np.array([0.5, 1.0, 1.5, 2.0])
+    y_lo, y_hi = constant_bbox(bbox, q_bbox)
+
+    np.testing.assert_allclose(y_lo, np.array([[1.5, 3.0, 1.5, 2.0]]))
+    np.testing.assert_allclose(y_hi, np.array([[0.5, 1.0, 4.5, 6.0]]))
+
+    with pytest.raises(RuntimeError):
+        cqr_interval(np.array([1.0, 2.0, 3.0]), 0.5)
+
+    with pytest.raises(RuntimeError):
+        constant_bbox(np.array([[1.0, 2.0, 3.0]]), q_bbox)
+
+
+def test_classwise_lac_and_raps_variants():
+    y_pred = np.array([[0.7, 0.2, 0.1], [0.2, 0.5, 0.3]])
+    classwise_sets = classwise_lac_set(y_pred, np.array([0.2, 0.4, 0.8]))[0]
+    assert classwise_sets == [[], [2]]
+
+    raps_sets = raps_set(y_pred, scores_quantile=0.65, lambd=0.1, k_reg=1, rand=False)[0]
+    assert all(isinstance(pred_set, list) for pred_set in raps_sets)
+    assert len(raps_sets) == len(y_pred)
+
+    with pytest.raises(ValueError):
+        raps_set_builder(lambd=-1)
+    with pytest.raises(ValueError):
+        raps_set_builder(k_reg=-1)
+
+    built = raps_set_builder(lambd=0.1, k_reg=1, rand=False)
+    assert built(y_pred, 0.65)[0] == raps_sets

--- a/tests/api/test_prediction_wrappers.py
+++ b/tests/api/test_prediction_wrappers.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import numpy as np
+import pytest
+
+from deel.puncc.api.prediction import BasePredictor
+from deel.puncc.api.prediction import DualPredictor
+from deel.puncc.api.prediction import IdPredictor
+from deel.puncc.api.prediction import MeanVarPredictor
+
+
+class DummyModel:
+    def __init__(self, prediction=None):
+        self.prediction = np.array([1.0, 2.0]) if prediction is None else prediction
+        self.fit_calls = []
+        self.compile_calls = []
+
+    def compile(self, **kwargs):
+        self.compile_calls.append(kwargs)
+
+    def fit(self, X, y=None, **kwargs):
+        self.fit_calls.append((X, y, kwargs))
+
+    def predict(self, X, **kwargs):
+        del X, kwargs
+        return self.prediction
+
+
+class UncopyableModel:
+    def __deepcopy__(self, memo):
+        raise RuntimeError("no deepcopy")
+
+    def predict(self, X, **kwargs):
+        del X, kwargs
+        return [1.0, 2.0]
+
+
+def test_id_predictor_branches():
+    predictor = IdPredictor(model=DummyModel(), tag="x")
+
+    assert predictor.kwargs == {"tag": "x"}
+    assert predictor.predict(np.array([1.0, 2.0])) is not None
+    np.testing.assert_allclose(
+        predictor.predict_with_model(np.array([0.0])),
+        np.array([1.0, 2.0]),
+    )
+
+    with pytest.raises(RuntimeError):
+        predictor.fit(np.array([1.0]))
+
+
+def test_dual_predictor_validation_and_non_numpy_prediction():
+    model1 = DummyModel(prediction=np.array([1.0, 2.0]))
+    model2 = DummyModel(prediction=np.array([3.0, 4.0]))
+    predictor = DualPredictor(
+        models=[model1, model2],
+        is_trained=[False, True],
+        compile_args=[{"alpha": 1}, {}],
+    )
+
+    assert model1.compile_calls == [{"alpha": 1}]
+    assert predictor.get_is_trained() is False
+
+    predictor.fit(np.array([[1.0], [2.0]]), np.array([1.0, 2.0]), [{}, {}])
+    assert len(model1.fit_calls) == 1
+    assert len(model2.fit_calls) == 0
+
+    np.testing.assert_allclose(
+        predictor.predict(np.array([[1.0], [2.0]]), [{}, {}]),
+        np.array([[1.0, 3.0], [2.0, 4.0]]),
+    )
+
+    bad_predictor = DualPredictor(models=[UncopyableModel(), UncopyableModel()])
+    with pytest.raises(NotImplementedError):
+        bad_predictor.predict(np.array([[1.0]]), [{}, {}])
+
+
+def test_dual_predictor_copy_and_meanvar_fit():
+    model1 = DummyModel(prediction=np.array([1.0, 2.0]))
+    model2 = DummyModel(prediction=np.array([3.0, 4.0]))
+    predictor = DualPredictor(models=[model1, model2])
+    predictor.extra = "kept"
+
+    copied = predictor.copy()
+
+    assert copied is not predictor
+    assert copied.extra == "kept"
+    assert copied.models[0] is not predictor.models[0]
+
+    mean_model = DummyModel(prediction=np.array([2.0, 4.0]))
+    sigma_model = DummyModel(prediction=np.array([0.5, 0.25]))
+    meanvar = MeanVarPredictor(models=[mean_model, sigma_model])
+
+    X = np.array([[1.0], [2.0]])
+    y = np.array([1.0, 3.0])
+    meanvar.fit(X, y, [{}, {"epochs": 2}])
+
+    assert len(mean_model.fit_calls) == 1
+    assert len(sigma_model.fit_calls) == 1
+    sigma_fit_args = sigma_model.fit_calls[0]
+    np.testing.assert_allclose(sigma_fit_args[1], np.array([1.0, 1.0]))
+    assert sigma_fit_args[2] == {"epochs": 2}
+
+
+def test_dual_predictor_copy_runtime_error_branch(monkeypatch):
+    import deel.puncc.api.prediction as prediction_module
+
+    class ReallyUncopyable:
+        def __deepcopy__(self, memo):
+            raise RuntimeError("no deepcopy")
+
+    predictor = DualPredictor(models=[ReallyUncopyable(), ReallyUncopyable()])
+
+    class FailingClone:
+        @staticmethod
+        def clone_model(model):
+            raise RuntimeError("clone failed")
+
+    class FakeKeras:
+        models = FailingClone()
+
+    class FakeTf:
+        keras = FakeKeras()
+
+    monkeypatch.setattr(prediction_module.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(prediction_module, "tf", FakeTf())
+
+    with pytest.raises(RuntimeError, match="Cannot copy models"):
+        predictor.copy()
+
+
+def test_dual_predictor_copy_re_raises_without_tensorflow(monkeypatch):
+    import deel.puncc.api.prediction as prediction_module
+
+    class ReallyUncopyable:
+        def __deepcopy__(self, memo):
+            raise RuntimeError("no deepcopy")
+
+    predictor = DualPredictor(models=[ReallyUncopyable(), ReallyUncopyable()])
+    monkeypatch.setattr(prediction_module.importlib.util, "find_spec", lambda name: None)
+
+    with pytest.raises(Exception, match="no deepcopy"):
+        predictor.copy()
+
+
+def test_base_predictor_copy_preserves_extra_attributes():
+    predictor = BasePredictor(DummyModel(), is_trained=True)
+    predictor.extra = {"k": 1}
+
+    copied = predictor.copy()
+
+    assert copied is not predictor
+    assert copied.extra == {"k": 1}

--- a/tests/api/test_splitting.py
+++ b/tests/api/test_splitting.py
@@ -27,6 +27,7 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 
+from deel.puncc.api.splitting import BaseSplitter
 from deel.puncc.api.splitting import IdSplitter
 from deel.puncc.api.splitting import KFoldSplitter
 from deel.puncc.api.splitting import RandomSplitter
@@ -112,3 +113,10 @@ class SplitterCheck(unittest.TestCase):
         random_splits_tf = random_splitter(self.X_tf, self.y_tf)
         self.assertEqual(len(random_splits_tf), 1)
         self.assertEqual(len(random_splits_tf[0]), 4)
+
+
+def test_base_splitter_call_raises_not_implemented():
+    splitter = BaseSplitter(random_state=0)
+
+    with unittest.TestCase().assertRaises(NotImplementedError):
+        splitter()

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -27,12 +27,18 @@ import pandas as pd
 import pytest
 import tensorflow as tf
 
+from deel.puncc.api.utils import _n_features
+from deel.puncc.api.utils import _n_samples
 from deel.puncc.api.utils import alpha_calib_check
 from deel.puncc.api.utils import dual_predictor_check
 from deel.puncc.api.utils import features_len_check
+from deel.puncc.api.utils import generate_leverage_func
 from deel.puncc.api.utils import get_min_max_alpha_calib
 from deel.puncc.api.utils import hungarian_assignment
 from deel.puncc.api.utils import quantile
+from deel.puncc.api.utils import quantile_unweighted
+from deel.puncc.api.utils import quantile_weighted
+from deel.puncc.api.utils import quantile_weighted_unidim
 from deel.puncc.api.utils import sample_len_check
 from deel.puncc.api.utils import supported_bbox_shape_check
 from deel.puncc.api.utils import supported_dual_models_shape_check
@@ -392,3 +398,156 @@ def test_hungarian_assignment_pads_predictions_and_filters_by_iou():
     np.testing.assert_array_equal(aligned_predictions, np.array([[0, 0, 2, 2]]))
     np.testing.assert_array_equal(aligned_truth, np.array([[0, 0, 2, 2]]))
     np.testing.assert_array_equal(valid_indices, np.array([True, False, False]))
+
+
+def test_n_samples_and_n_features_fallbacks():
+    class NoShapeLen:
+        def __len__(self):
+            return 3
+
+    class NoFeatureShape:
+        def __len__(self):
+            return 2
+
+        def __getitem__(self, idx):
+            return [1, 2, 3][idx]
+
+    assert _n_samples(NoShapeLen()) == 3
+    assert _n_features([]) == 0
+    assert _n_features([[1, 2, 3], [4, 5, 6]]) == 3
+
+
+def test_logit_and_supported_type_error_branches():
+    from deel.puncc.api.utils import logit_normalization_check
+
+    with pytest.raises(ValueError, match="Logits must some to 1"):
+        logit_normalization_check(np.array([[0.2, 0.2], [0.1, 0.1]]))
+
+    class Unconvertible:
+        def __array__(self, dtype=None):
+            raise TypeError("cannot convert")
+
+    with pytest.raises(TypeError, match="Unsupported data type"):
+        supported_types_check(Unconvertible())
+
+
+def test_supported_dual_and_bbox_valid_shapes():
+    supported_dual_models_shape_check(
+        np.array([[1.0, 0.5], [2.0, 0.7]]),
+        np.array([1.0, 2.0]),
+    )
+    supported_bbox_shape_check(
+        np.array([[0, 1, 2, 3]]),
+        np.array([[0, 1, 2, 3]]),
+    )
+
+
+def test_alpha_calib_check_positive_complement_branch():
+    with pytest.raises(ValueError, match="too small"):
+        alpha_calib_check(alpha=0.0, n=10, complement_check=True)
+
+    with pytest.raises(ValueError, match="too large"):
+        alpha_calib_check(alpha=0.95, n=10, complement_check=True)
+
+
+def test_alpha_calib_check_zero_branch_via_monkeypatch(monkeypatch):
+    import deel.puncc.api.utils as utils_module
+
+    calls = {"count": 0}
+
+    def fake_any(value):
+        calls["count"] += 1
+        if calls["count"] in (1, 2, 3):
+            return False
+        return True
+
+    monkeypatch.setattr(utils_module.np, "any", fake_any)
+
+    with pytest.raises(ValueError, match="too small"):
+        utils_module.alpha_calib_check(alpha=0.0, n=10, complement_check=True)
+
+
+def test_quantile_validation_branches():
+    with pytest.raises(ValueError, match="open interval"):
+        quantile(np.array([1, 2, 3]), q=1.0)
+
+    with pytest.raises(ValueError, match="axis value cannot coincide"):
+        quantile_unweighted(np.array([[1, 2], [3, 4]]), q=np.array([0.5, 0.5]), axis=1, feature_axis=1)
+
+    with pytest.raises(ValueError, match="same number of features"):
+        quantile_unweighted(np.array([[1, 2], [3, 4]]), q=np.array([0.5]), axis=0, feature_axis=1)
+
+    with pytest.raises(ValueError, match="w must be a 1D array"):
+        quantile_weighted_unidim(np.array([1, 2]), 0.5, np.array([[0.5, 0.5]]))
+
+    with pytest.raises(ValueError, match="a and w must have the same length"):
+        quantile_weighted_unidim(np.array([1, 2]), 0.5, np.array([1.0]))
+
+    with pytest.raises(RuntimeError, match="not normalized"):
+        quantile_weighted_unidim(np.array([1, 2]), 0.5, np.array([0.2, 0.2]))
+
+    with pytest.raises(ValueError, match="axis value cannot coincide"):
+        quantile_weighted(
+            np.array([[1, 2], [3, 4]]),
+            q=0.5,
+            w=np.array([0.5, 0.5]),
+            axis=1,
+            feature_axis=1,
+        )
+
+    with pytest.raises(ValueError, match="same length as a.shape"):
+        quantile_weighted(
+            np.array([[1, 2], [3, 4]]),
+            q=0.5,
+            w=np.array([0.5]),
+            axis=0,
+        )
+
+    with pytest.raises(ValueError, match="same number of features"):
+        quantile_weighted(
+            np.array([[1, 2], [3, 4]]),
+            q=np.array([0.5]),
+            w=np.array([0.5, 0.5]),
+            axis=0,
+            feature_axis=1,
+        )
+
+    with pytest.raises(ValueError, match="same number of features"):
+        quantile_weighted(
+            np.array([[1, 2], [3, 4]]),
+            q=np.array([0.5, 0.6]),
+            w=np.array([[0.5], [0.5]]),
+            axis=0,
+            feature_axis=1,
+        )
+
+    with pytest.raises(TypeError):
+        quantile_weighted(
+            np.array([[1, 2], [3, 4]]),
+            q=0.5,
+            w=np.array([[0.5, 0.5], [0.5, 0.5]]),
+            axis=0,
+            feature_axis=1,
+        )
+
+
+def test_generate_leverage_func_returns_scores():
+    X = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    leverage_func = generate_leverage_func(X)
+    scores = leverage_func(np.array([[1.0, 0.0], [0.5, 0.5]]))
+
+    assert scores.shape == (2,)
+    assert np.all(scores >= 0)
+
+
+def test_hungarian_assignment_no_padding_branch():
+    predicted_bboxes = np.array([[0, 0, 2, 2], [4, 4, 6, 6]])
+    true_bboxes = np.array([[0, 0, 2, 2], [4, 4, 6, 6]])
+
+    aligned_predictions, aligned_truth, valid_indices = hungarian_assignment(
+        predicted_bboxes, true_bboxes, min_iou=0.1
+    )
+
+    np.testing.assert_array_equal(aligned_predictions, predicted_bboxes)
+    np.testing.assert_array_equal(aligned_truth, true_bboxes)
+    np.testing.assert_array_equal(valid_indices, np.array([True, True]))

--- a/tests/test_anomaly_detection_seed.py
+++ b/tests/test_anomaly_detection_seed.py
@@ -84,3 +84,66 @@ def test_anomaly_detection(rand_anomaly_detection_data, alpha, random_state):
     np.testing.assert_allclose(
         not_anomalies.shape, RESULTS["split_cad"]["normal_shape"]
     )
+
+
+class DummyAnomalyPredictor:
+    def __init__(self, trained=False):
+        self.is_trained = trained
+        self.fit_calls = []
+
+    def fit(self, X, **kwargs):
+        self.fit_calls.append((np.asarray(X), kwargs))
+        self.is_trained = True
+
+    def predict(self, X):
+        return np.sum(np.asarray(X), axis=1)
+
+
+def test_splitcad_fit_with_random_split_trains_predictor():
+    z = np.arange(20, dtype=float).reshape(10, 2)
+    predictor = DummyAnomalyPredictor()
+    cad = SplitCAD(predictor, train=True, random_state=0)
+
+    cad.fit(z=z, fit_ratio=0.6)
+    preds = cad.predict(z, alpha=0.5)
+
+    assert predictor.is_trained is True
+    assert len(predictor.fit_calls) == 1
+    assert preds.shape == (10,)
+    assert preds.dtype == np.bool_
+
+
+def test_splitcad_fit_with_pretrained_predictor_skips_training():
+    z_calib = np.array([[0.0, 0.5], [0.5, 0.0], [0.1, 0.2]])
+    predictor = DummyAnomalyPredictor(trained=True)
+    cad = SplitCAD(predictor, train=False)
+
+    cad.fit(z_calib=z_calib)
+
+    assert predictor.fit_calls == []
+
+
+def test_splitcad_fit_raises_with_untrained_predictor_when_train_false():
+    predictor = DummyAnomalyPredictor(trained=False)
+    cad = SplitCAD(predictor, train=False)
+
+    with pytest.raises(RuntimeError):
+        cad.fit(
+            z_fit=np.array([[0.0, 0.0], [1.0, 1.0]]),
+            z_calib=np.array([[0.0, 0.0], [1.0, 1.0]]),
+        )
+
+
+def test_splitcad_fit_raises_without_data():
+    cad = SplitCAD(DummyAnomalyPredictor(), train=True)
+
+    with pytest.raises(RuntimeError):
+        cad.fit()
+
+
+def test_splitcad_predict_raises_when_forced_to_unfit_state():
+    cad = SplitCAD(DummyAnomalyPredictor(), train=True)
+    cad._SplitCAD__is_fit = None
+
+    with pytest.raises(RuntimeError):
+        cad.predict(np.array([[0.0, 1.0]]), alpha=0.1)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import numpy as np
 import pytest
 

--- a/tests/test_object_detection.py
+++ b/tests/test_object_detection.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import numpy as np
 import pytest
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import matplotlib
 
 matplotlib.use("Agg")

--- a/tests/test_wrapper_branches.py
+++ b/tests/test_wrapper_branches.py
@@ -1,0 +1,518 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from PIL import Image
+
+from deel.puncc.api.conformalization import ConformalPredictor
+from deel.puncc.api.conformalization import CrossValCpAggregator
+from deel.puncc.api.prediction import BasePredictor
+from deel.puncc.classification import LAC
+from deel.puncc.classification import RAPS
+from deel.puncc.plotting import draw_bounding_box
+from deel.puncc.plotting import plot_prediction_intervals
+from deel.puncc.regression import CVPlus
+from deel.puncc.regression import EnbPI
+from deel.puncc.regression import SplitCP
+
+
+class DummyConformalPredictor:
+    def __init__(self, prediction=None):
+        self.splitter = None
+        self.prediction = prediction if prediction is not None else (np.array([1.0]), np.array([0.0]), np.array([2.0]))
+        self.nconf_scores = {0: np.array([1.0, 2.0])}
+
+    def fit(self, X=None, y=None, **kwargs):
+        self.fit_args = (X, y, kwargs)
+
+    def predict(self, X, alpha):
+        del X, alpha
+        return self.prediction
+
+    def get_nonconformity_scores(self):
+        return self.nconf_scores
+
+
+class DummyPredictor:
+    def __init__(self, trained=True):
+        self.is_trained = trained
+
+    def copy(self):
+        return DummyPredictor(trained=self.is_trained)
+
+    def fit(self, X, y, **kwargs):
+        self.fit_args = (X, y, kwargs)
+
+    def predict(self, X=None, **kwargs):
+        del kwargs
+        X = np.asarray(X)
+        return np.ones(len(X))
+
+    def get_is_trained(self):
+        return self.is_trained
+
+
+class BareModelWithFitPredict:
+    def fit(self, X, y, **kwargs):
+        self.fit_args = (X, y, kwargs)
+
+    def predict(self, X):
+        X = np.asarray(X)
+        return np.ones(len(X))
+
+
+class DummyCalibrator:
+    def __init__(self, weight_func=None):
+        self.weight_func = weight_func
+        self._scores = np.array([1.0, 2.0])
+
+    def fit(self, **kwargs):
+        self.fit_kwargs = kwargs
+
+    def barber_weights(self, weights):
+        return np.asarray(weights) / np.sum(weights)
+
+    def set_norm_weights(self, weights):
+        self._norm_weights = weights
+
+    def get_nonconformity_scores(self):
+        return self._scores
+
+    def get_weights(self):
+        return getattr(self, "_norm_weights", None)
+
+    def get_norm_weights(self):
+        return getattr(self, "_norm_weights", None)
+
+    def calibrate(self, X, alpha, y_pred, weights=None, correction=None):
+        del X, alpha, correction
+        return (y_pred - 1, y_pred + 1)
+
+
+class BarePredictModel:
+    def predict(self, X):
+        return np.asarray(X)
+
+
+class NoFitPredictModel:
+    def predict(self, X):
+        return np.asarray(X)
+
+
+def test_lac_wrapper_branches():
+    lac = LAC(DummyPredictor())
+    lac.conformal_predictor = DummyConformalPredictor(prediction=(np.array([0.8]), ([0],)))
+
+    y_pred, set_pred = lac.predict(np.array([[1.0]]), alpha=0.1)
+    np.testing.assert_allclose(y_pred, np.array([0.8]))
+    assert set_pred == ([0],)
+
+    lac.conformal_predictor = None
+    with pytest.raises(AttributeError):
+        lac.predict(np.array([[1.0]]), alpha=0.1)
+
+    lac2 = LAC(DummyPredictor(trained=False), train=False)
+    lac2.predictor.is_trained = True
+    lac2.conformal_predictor = DummyConformalPredictor()
+    lac2.fit(
+        X_calib=np.array([[1.0]]),
+        y_calib=np.array([1]),
+    )
+    assert lac2.conformal_predictor.fit_args[0] is None
+    assert lac2.conformal_predictor.fit_args[1] is None
+
+    lac3 = LAC(DummyPredictor(), train=True)
+    lac3.conformal_predictor = DummyConformalPredictor()
+    with pytest.raises(RuntimeError, match="Argument 'train' is True"):
+        lac3.fit(
+            X_calib=np.array([[1.0]]),
+            y_calib=np.array([1]),
+        )
+
+    lac4 = LAC(DummyPredictor())
+    lac4.conformal_predictor = DummyConformalPredictor()
+    lac4.fit(X=np.array([[1.0], [2.0]]), y=np.array([0, 1]))
+    assert lac4.conformal_predictor.splitter is not None
+
+    lac5 = LAC(DummyPredictor())
+    lac5.conformal_predictor = DummyConformalPredictor()
+    lac5.fit(
+        X_fit=np.array([[1.0]]),
+        y_fit=np.array([1]),
+        X_calib=np.array([[2.0]]),
+        y_calib=np.array([0]),
+    )
+    assert lac5.conformal_predictor.splitter is not None
+
+    lac6 = LAC(DummyPredictor())
+    lac6.conformal_predictor = DummyConformalPredictor()
+    with pytest.raises(RuntimeError, match="No dataset provided"):
+        lac6.fit()
+
+    lac7 = LAC(DummyPredictor())
+    lac7.conformal_predictor = DummyConformalPredictor()
+    np.testing.assert_allclose(lac7.get_nonconformity_scores(), np.array([1.0, 2.0]))
+    lac7.conformal_predictor.nconf_scores = {
+        0: np.array([1.0]),
+        1: np.array([2.0]),
+    }
+    assert isinstance(lac7.get_nonconformity_scores(), dict)
+
+
+def test_raps_wrapper_branches():
+    raps = RAPS(DummyPredictor())
+    raps.conformal_predictor = DummyConformalPredictor(prediction=(np.array([0.7]), ([0, 1],)))
+
+    y_pred, set_pred = raps.predict(np.array([[1.0]]), alpha=0.1)
+    np.testing.assert_allclose(y_pred, np.array([0.7]))
+    assert set_pred == ([0, 1],)
+
+    raps.conformal_predictor = None
+    with pytest.raises(RuntimeError):
+        raps.predict(np.array([[1.0]]), alpha=0.1)
+
+    raps2 = RAPS(DummyPredictor())
+    raps2.conformal_predictor = DummyConformalPredictor()
+    raps2.fit(X=np.array([[1.0], [2.0]]), y=np.array([0, 1]))
+    assert raps2.conformal_predictor.splitter is not None
+
+    raps3 = RAPS(DummyPredictor())
+    raps3.conformal_predictor = DummyConformalPredictor()
+    raps3.fit(
+        X_calib=np.array([[1.0]]),
+        y_calib=np.array([1]),
+    )
+    assert raps3.conformal_predictor.splitter is not None
+
+    raps4 = RAPS(DummyPredictor(trained=False), train=False)
+    raps4.conformal_predictor = DummyConformalPredictor()
+    with pytest.raises(RuntimeError, match="No dataset provided"):
+        raps4.fit(
+            X_calib=np.array([[1.0]]),
+            y_calib=np.array([1]),
+        )
+
+    raps5 = RAPS(DummyPredictor())
+    raps5.conformal_predictor = DummyConformalPredictor()
+    with pytest.raises(RuntimeError, match="No dataset provided"):
+        raps5.fit()
+
+
+def test_splitcp_wrapper_branches():
+    split_cp = SplitCP(DummyPredictor())
+    split_cp.conformal_predictor = DummyConformalPredictor()
+    y_pred, y_lo, y_hi = split_cp.predict(np.array([[1.0]]), alpha=0.1)
+    np.testing.assert_allclose(y_pred, np.array([1.0]))
+    np.testing.assert_allclose(y_lo, np.array([0.0]))
+    np.testing.assert_allclose(y_hi, np.array([2.0]))
+
+    del split_cp.conformal_predictor
+    with pytest.raises(AttributeError):
+        split_cp.predict(np.array([[1.0]]), alpha=0.1)
+
+
+def test_enbpi_branch_methods():
+    enbpi = EnbPI(DummyPredictor(), B=1)
+    enbpi.residuals = [1.0]
+
+    with pytest.raises(RuntimeError):
+        enbpi.predict(np.array([[1.0]]), alpha=0.1)
+
+    enbpi._boot_predictors = [DummyPredictor()]
+    enbpi.residuals = [1.0, 2.0]
+    enbpi._oob_matrix = np.array([[1.0]])
+    y_pred, y_lo, y_hi = enbpi.predict(np.array([[1.0]]), alpha=0.1)
+    assert len(y_pred) == len(y_lo) == len(y_hi) == 1
+
+    enbpi._boot_predictors = None
+    enbpi.residuals = [1.0]
+    with pytest.raises(RuntimeError):
+        enbpi.predict(np.array([[1.0]]), alpha=0.1, y_true=np.array([1.0]), s=1)
+
+    enbpi._boot_predictors = [DummyPredictor()]
+    enbpi.residuals = [1.0]
+    enbpi._oob_matrix = np.array([[1.0]])
+    enbpi.B = 1
+    y_pred_scalar, _, _ = enbpi.predict(np.array([[1.0]]), alpha=0.1)
+    assert len(y_pred_scalar) == 1
+
+
+def test_plotting_branch_cases(tmp_path):
+    ax = plot_prediction_intervals(
+        y_true=np.array([1.0, 2.0]),
+        y_pred=None,
+        y_pred_lower=None,
+        y_pred_upper=None,
+        X=None,
+    )
+    assert ax.get_title() == ""
+    plt.close(ax.figure)
+
+    ax2 = plot_prediction_intervals(
+        y_true=np.array([2.0, 2.0]),
+        y_pred=np.array([2.0, 2.0]),
+        y_pred_lower=np.array([1.5, 1.5]),
+        y_pred_upper=np.array([2.5, 2.5]),
+        X=np.array([1.0, 1.0]),
+        loc="lower right",
+    )
+    xmin, xmax = ax2.get_xlim()
+    assert xmin < 1.0 < xmax
+    plt.close(ax2.figure)
+
+    before_font = matplotlib.rcParams["font.family"]
+    ax3 = plot_prediction_intervals(
+        y_true=np.array([1.0, 3.0]),
+        y_pred=np.array([1.5, 2.5]),
+        y_pred_lower=np.array([0.5, 1.5]),
+        y_pred_upper=np.array([2.5, 3.5]),
+        figsize=(6, 4),
+    )
+    assert ax3.get_title() == "Prediction Intervals | coverage=1.000"
+    assert matplotlib.rcParams["font.family"] == before_font
+    plt.close(ax3.figure)
+
+    image_path = tmp_path / "bbox.png"
+    Image.new("RGB", (10, 10), color="white").save(image_path)
+    im = draw_bounding_box(image_path=str(image_path), legend="loaded", show=False)
+    assert im.size == (10, 10)
+
+    image = Image.new("RGB", (10, 10), color="white")
+    image.custom_lines = []
+    image.legends = []
+    shown = draw_bounding_box(image=image, show=True, legend="")
+    assert shown.size == (10, 10)
+
+    image_with_legend = Image.new("RGB", (10, 10), color="white")
+    shown_with_legend = draw_bounding_box(
+        image=image_with_legend,
+        box=(1, 1, 5, 5),
+        legend="box",
+        show=True,
+    )
+    assert shown_with_legend.legends == ["box"]
+    plt.close("all")
+
+
+def test_conformalization_guard_and_aggregator_branches(tmp_path):
+    with pytest.raises(RuntimeError):
+        ConformalPredictor(
+            calibrator=DummyCalibrator(),
+            predictor=object(),
+            splitter=object(),
+        )
+
+    with pytest.raises(RuntimeError):
+        ConformalPredictor(
+            calibrator=DummyCalibrator(),
+            predictor=BarePredictModel(),
+            splitter=object(),
+            train=True,
+        )
+
+    wrapped = ConformalPredictor(
+        calibrator=DummyCalibrator(),
+        predictor=BareModelWithFitPredict(),
+        splitter=object(),
+        train=True,
+    )
+    assert isinstance(wrapped.predictor, BasePredictor)
+
+    cp = ConformalPredictor(
+        calibrator=DummyCalibrator(),
+        predictor=BarePredictModel(),
+        splitter=object(),
+        train=False,
+    )
+    with pytest.raises(RuntimeError):
+        ConformalPredictor(
+            calibrator=DummyCalibrator(),
+            predictor=DummyPredictor(),
+            splitter=object(),
+            method="bad",
+        )
+
+    with pytest.raises(RuntimeError):
+        cp.get_nonconformity_scores()
+    with pytest.raises(RuntimeError):
+        cp.get_weights()
+    with pytest.raises(RuntimeError):
+        cp.predict(np.array([[1.0]]), alpha=0.1)
+
+    cp.splitter = None
+    cp.fit(np.array([[1.0], [2.0]]), np.array([1.0, 2.0]))
+    assert cp.get_nonconformity_scores() is not None
+    assert cp.get_weights() == {0: None}
+
+    cp_untrained = ConformalPredictor(
+        calibrator=DummyCalibrator(),
+        predictor=DummyPredictor(trained=False),
+        splitter=type("MultiSplitter", (), {"__call__": lambda self, X, y: [(X, y, X, y), (X, y, X, y)]})(),
+        train=False,
+    )
+    with pytest.raises(RuntimeError):
+        cp_untrained.fit(np.array([[1.0], [2.0]]), np.array([1.0, 2.0]))
+
+    cp_bad_splitter = ConformalPredictor(
+        calibrator=DummyCalibrator(),
+        predictor=DummyPredictor(),
+        splitter=None,
+        train=False,
+    )
+    cp_bad_splitter.train = True
+    with pytest.raises(RuntimeError):
+        cp_bad_splitter.fit(np.array([[1.0], [2.0]]), np.array([1.0, 2.0]))
+
+    weighted_cp = ConformalPredictor(
+        calibrator=DummyCalibrator(weight_func=lambda X: np.arange(1, len(X) + 1)),
+        predictor=DummyPredictor(),
+        splitter=None,
+        train=False,
+    )
+    weighted_cp.fit(np.array([[1.0], [2.0]]), np.array([1.0, 2.0]))
+    np.testing.assert_allclose(weighted_cp.get_weights()[0], np.array([1 / 3, 2 / 3]))
+
+    cached_cp = ConformalPredictor(
+        calibrator=DummyCalibrator(),
+        predictor=DummyPredictor(),
+        splitter=type(
+            "SingleSplit",
+            (),
+            {"__call__": lambda self, X, y: [(X[:1], y[:1], X[1:], y[1:])]},
+        )(),
+        train=False,
+    )
+    cached_cp.predictor.is_trained = True
+    cached_cp.fit(np.array([[1.0], [2.0]]), np.array([1.0, 2.0]))
+    cached_cp.fit(np.array([[3.0], [4.0]]), np.array([3.0, 4.0]), use_cached=True)
+    assert cached_cp._cv_cp_agg.K == 2
+
+    path = tmp_path / "cp.pkl"
+    cp.save(path, save_data=True)
+    loaded = ConformalPredictor.load(path)
+    assert isinstance(loaded, ConformalPredictor)
+
+    agg = CrossValCpAggregator(K=1)
+    dummy_predictor = DummyPredictor()
+    dummy_calibrator = DummyCalibrator(weight_func=lambda X: np.array([0.5] * len(X)))
+    dummy_calibrator.set_norm_weights(np.array([0.5, 0.5]))
+    agg.append_predictor(0, dummy_predictor)
+    agg.append_calibrator(0, dummy_calibrator)
+    y_pred, y_lo, y_hi = agg.predict(np.array([[1.0], [2.0]]), alpha=0.1)
+    assert y_pred.shape == y_lo.shape == y_hi.shape
+    np.testing.assert_allclose(agg.get_weights()[0], np.array([0.5, 0.5]))
+
+    bad_agg = CrossValCpAggregator(K=1)
+    bad_agg._predictors = {0: dummy_predictor}
+    bad_agg._calibrators = {1: dummy_calibrator}
+    with pytest.raises(AssertionError):
+        bad_agg.predict(np.array([[1.0]]), alpha=0.1)
+
+    with pytest.raises(NotImplementedError):
+        CrossValCpAggregator(K=1, method="bad")
+
+    import deel.puncc.api.conformalization as conformalization_module
+
+    class FakeCvPlusCalibrator:
+        def __init__(self, calibrators):
+            self.calibrators = calibrators
+
+        def calibrate(self, X, kfold_predictors_dict, alpha):
+            del kfold_predictors_dict, alpha
+            X = np.asarray(X)
+            return np.zeros(len(X)), np.ones(len(X))
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(conformalization_module, "CvPlusCalibrator", FakeCvPlusCalibrator)
+    try:
+        cv_agg = CrossValCpAggregator(K=2)
+        cv_agg._predictors = {0: dummy_predictor, 1: dummy_predictor}
+        cv_agg._calibrators = {0: dummy_calibrator, 1: dummy_calibrator}
+        y_pred, y_lo, y_hi = cv_agg.predict(np.array([[1.0], [2.0]]), alpha=0.1)
+        assert y_pred is None
+        np.testing.assert_allclose(y_lo, np.zeros(2))
+        np.testing.assert_allclose(y_hi, np.ones(2))
+
+        cv_agg.method = "bad"
+        with pytest.raises(RuntimeError):
+            cv_agg.predict(np.array([[1.0]]), alpha=0.1)
+    finally:
+        monkeypatch.undo()
+
+
+def test_splitcp_and_enbpi_regression_branches(monkeypatch):
+    cv_plus = CVPlus.__new__(CVPlus)
+    with pytest.raises(RuntimeError):
+        cv_plus.predict(np.array([[1.0]]), alpha=0.1)
+
+    cv_plus2 = CVPlus.__new__(CVPlus)
+    cv_plus2.conformal_predictor = DummyConformalPredictor()
+    np.testing.assert_allclose(
+        cv_plus2.get_nonconformity_scores()[0], np.array([1.0, 2.0])
+    )
+
+    enbpi = EnbPI(DummyPredictor(), B=1, random_state=7)
+    assert enbpi.random_state == 7
+
+    def resample_none(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    import deel.puncc.regression as regression_module
+
+    monkeypatch.setattr(regression_module, "resample", resample_none)
+    with pytest.raises(RuntimeError, match="Bootstrap dataset is empty"):
+        enbpi.fit(np.array([[1.0], [2.0]]), np.array([1.0, 2.0]))
+
+    def resample_no_oob_for_first_unit(horizon_indices, **kwargs):
+        del kwargs
+        return np.zeros(len(horizon_indices), dtype=int)
+
+    monkeypatch.setattr(regression_module, "resample", resample_no_oob_for_first_unit)
+    with pytest.raises(RuntimeError, match='Increase "B"'):
+        enbpi.fit(np.array([[1.0], [2.0]]), np.array([1.0, 2.0]))
+
+    enbpi = EnbPI(DummyPredictor(), B=1, agg_func_loo=lambda arr, axis=0: np.mean(arr, axis=axis))
+    enbpi.residuals = [1.0, 2.0, 3.0]
+    enbpi._boot_predictors = [DummyPredictor()]
+    enbpi._oob_matrix = np.array([[1.0]])
+    y_pred, y_lo, y_hi = enbpi.predict(
+        np.array([[1.0], [2.0], [3.0], [4.0]]),
+        alpha=0.1,
+        y_true=np.array([1.0, 2.0, 3.0, 4.0]),
+        s=2,
+    )
+    assert y_pred.shape == y_lo.shape == y_hi.shape == (4,)
+
+    scalar_enbpi = EnbPI(DummyPredictor(), B=1, agg_func_loo=lambda arr, axis=0: np.array(1.5))
+    scalar_enbpi.residuals = [1.0, 2.0]
+    scalar_enbpi._boot_predictors = [DummyPredictor()]
+    scalar_enbpi._oob_matrix = np.array([[1.0]])
+    y_pred_scalar, _, _ = scalar_enbpi.predict(np.array([[1.0]]), alpha=0.1)
+    assert y_pred_scalar.shape == (1,)


### PR DESCRIPTION
This PR adds missing tests to achieve full test coverage across the codebase. The added tests focus on both functional correctness and branching coverage to ensure robustness across edge cases.

## Changes

- Extend backend test coverage to handle multiple data types.
- Expand calibration tests to include weighted cases, class-wise behavior and error paths
- Add branching tests to improve coverage of wrapper logic:
  - `tests/test_wrapper_branches.py`: classification, conformalization, plotting, and regression paths
  - `tests/api/test_prediction_wrappers.py`: predictor-related wrapper paths
- Add unit tests to cover branching paths for anomaly detection, metrics, prediction sets, etc.
- Mark two structurally unreachable fallback branches as excluded from coverage:
  - `deel/puncc/plotting.py:340`
  - `deel/puncc/regression.py:840`  
  These correspond to sanity checks that cannot be triggered given the current control flow.


