### PR TITLE
Abstraction of model copying in backend module

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -19,7 +19,9 @@ This file documents main changes across releases of **PUNCC**.
 - Corrected the definition of the prediction set for RAPS in theory overview 
 
 ### CI / Maintenance
-- Expanded API test coverage for backend-driven model copying and wrapper copy behavior
+- Expanded API test coverage for backend-driven model copying and predictor wrapper copy behavior.
+- Raised the minimum supported scikit-learn version to 1.5.0 to address security vulnerabilities in older releases.
+- Added alternative expected seed results in conformal regression tests for newer scikit-learn versions.
 
 ---
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -22,6 +22,7 @@ This file documents main changes across releases of **PUNCC**.
 - Expanded API test coverage for backend-driven model copying and predictor wrapper copy behavior.
 - Raised the minimum supported scikit-learn version to 1.5.0 to address security vulnerabilities in older releases.
 - Added alternative expected seed results in conformal regression tests for newer scikit-learn versions.
+- Removed py38 from tox envlist
 
 ---
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,25 @@ This file documents main changes across releases of **PUNCC**.
 
 ---
 
+## [0.9.2] - TBD
+
+### Added 
+- Backend-level model copy abstraction supporting sklearn, JAX, TensorFlow/Keras, and PyTorch models through a unified `copy_model` entrypoint
+
+### Changed
+- Refactored predictor wrappers to delegate model cloning to the backend abstraction 
+- Updated `TorchPredictor` experimental wrapper to reuse the shared backend copy mechanism
+- Avoid eager import (e.g. tensorflow) from prediction wrappers by detecting loaded frameworks through runtime module inspection
+
+### Fixed
+- Improved framework-agnostic model copy compatibility across predictor wrappers
+- Corrected the definition of the prediction set for RAPS in theory overview 
+
+### CI / Maintenance
+- Expanded API test coverage for backend-driven model copying and wrapper copy behavior
+
+---
+
 ## [0.9.1] - 2026-04-09
 
 ### Added

--- a/deel/puncc/api/backend.py
+++ b/deel/puncc/api/backend.py
@@ -29,15 +29,17 @@ PyTorch, JAX and TensorFlow objects.
 # pylint: disable=C0115,C0116,C0321,C0415,R0911,C0301
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
+import sys
 from typing import Any
+from typing import Callable
 from typing import Protocol
 from typing import Sequence
 from typing import Tuple
 from typing import runtime_checkable
 
 import numpy as _np
-import sys
 
 
 # -------------------------
@@ -63,6 +65,57 @@ def _is_tf(x: Any) -> bool:
 def _is_pandas(x: Any) -> bool:
     pd = sys.modules.get("pandas")
     return bool(pd) and isinstance(x, (pd.Series, pd.DataFrame, pd.Index))
+
+
+def _is_sklearn_model(model: Any) -> bool:
+    sklearn_base = sys.modules.get("sklearn.base")
+    return bool(sklearn_base) and isinstance(
+        model, getattr(sklearn_base, "BaseEstimator", ())
+    )
+
+
+def _is_torch_model(model: Any) -> bool:
+    torch = sys.modules.get("torch")
+    return bool(torch) and isinstance(model, getattr(torch.nn, "Module", ()))
+
+
+def _is_tensorflow_model(model: Any) -> bool:
+    tf = sys.modules.get("tensorflow")
+    keras = getattr(tf, "keras", None) if tf else None
+    return bool(keras) and isinstance(model, getattr(keras, "Model", ()))
+
+
+def _contains_jax_arrays(obj: Any, visited: set[int] | None = None) -> bool:
+    if visited is None:
+        visited = set()
+
+    obj_id = id(obj)
+    if obj_id in visited:  # pragma: no cover - recursion guard
+        return False
+    visited.add(obj_id)
+
+    if _is_jax(obj):
+        return True
+
+    if isinstance(obj, dict):
+        return any(_contains_jax_arrays(value, visited) for value in obj.values())
+
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        return any(_contains_jax_arrays(value, visited) for value in obj)
+
+    obj_dict = getattr(obj, "__dict__", None)
+    if isinstance(obj_dict, dict):
+        return any(_contains_jax_arrays(value, visited) for value in obj_dict.values())
+
+    return False
+
+
+def _is_jax_model(model: Any) -> bool:
+    if _is_jax(model):
+        return True
+    if "jax" not in sys.modules:
+        return False
+    return _contains_jax_arrays(model)
 
 
 def infer_backend(*xs: Any) -> str:
@@ -98,6 +151,77 @@ def infer_backend(*xs: Any) -> str:
         raise TypeError(f"Mixed backends are not supported: {sorted(kinds)}")
 
     return next(iter(kinds), "numpy")
+
+
+def infer_model_backend(model: Any) -> str:
+    """Infer backend name from a model-like object.
+
+    Supported model backends are ``sklearn``, ``torch``, ``tensorflow`` and
+    ``jax``. Everything else falls back to ``generic``.
+
+    :param Any model: model-like object to inspect.
+
+    :returns: inferred model backend name.
+    :rtype: str
+    """
+    if _is_tensorflow_model(model):
+        return "tensorflow"
+    if _is_torch_model(model):
+        return "torch"
+    if _is_sklearn_model(model):
+        return "sklearn"
+    if _is_jax_model(model):
+        return "jax"
+    return "generic"
+
+
+def _copy_deepcopy_model(model: Any) -> Any:
+    return deepcopy(model)
+
+
+def _copy_tensorflow_model(model: Any) -> Any:
+    tf = sys.modules.get("tensorflow")
+    if tf is None:  # pragma: no cover - defensive guard
+        raise RuntimeError(
+            "TensorFlow model copying requires the already-loaded tensorflow module."
+        )
+
+    copied_model = tf.keras.models.clone_model(model)
+    if hasattr(model, "get_weights") and hasattr(copied_model, "set_weights"):
+        try:
+            copied_model.set_weights(model.get_weights())
+        except Exception:
+            pass
+    return copied_model
+
+
+_MODEL_COPIERS: dict[str, Callable[[Any], Any]] = {
+    "generic": _copy_deepcopy_model,
+    "sklearn": _copy_deepcopy_model,
+    "torch": _copy_deepcopy_model,
+    "jax": _copy_deepcopy_model,
+    "tensorflow": _copy_tensorflow_model,
+}
+
+
+def copy_model(model: Any) -> Any:
+    """Copy a model-like object using the matching backend strategy.
+
+    :param Any model: model-like object to copy.
+
+    :returns: copied model.
+    :rtype: Any
+
+    :raises RuntimeError: if the model cannot be copied.
+    """
+    backend_name = infer_model_backend(model)
+    copier = _MODEL_COPIERS[backend_name]
+    try:
+        return copier(model)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cannot copy model with backend '{backend_name}': {exc}"
+        ) from exc
 
 
 # -------------------------

--- a/deel/puncc/api/backend.py
+++ b/deel/puncc/api/backend.py
@@ -57,10 +57,13 @@ def _is_jax(x: Any) -> bool:
     jnp = sys.modules.get("jax.numpy")
     if not (jax and jnp):
         return False
-    # jax.Array exists on newer JAX; keep jnp.ndarray for older
-    return isinstance(
-        x, (getattr(jax, "Array", ()), getattr(jnp, "ndarray", ()))
-    )
+
+    jax_array = getattr(jax, "Array", None)
+
+    if jax_array is not None:
+        return isinstance(x, (jax_array, jnp.ndarray))
+
+    return isinstance(x, jnp.ndarray)
 
 
 def _is_tf(x: Any) -> bool:

--- a/deel/puncc/api/backend.py
+++ b/deel/puncc/api/backend.py
@@ -26,6 +26,7 @@
 This module provides backend inference and a unified API over NumPy, pandas,
 PyTorch, JAX and TensorFlow objects.
 """
+
 # pylint: disable=C0115,C0116,C0321,C0415,R0911,C0301
 from __future__ import annotations
 
@@ -41,14 +42,15 @@ from typing import runtime_checkable
 
 import numpy as _np
 
-
 # -------------------------
 # Detection helpers
 # -------------------------
 
+
 def _is_torch(x: Any) -> bool:
     torch = sys.modules.get("torch")
     return bool(torch) and isinstance(x, torch.Tensor)
+
 
 def _is_jax(x: Any) -> bool:
     jax = sys.modules.get("jax")
@@ -56,11 +58,15 @@ def _is_jax(x: Any) -> bool:
     if not (jax and jnp):
         return False
     # jax.Array exists on newer JAX; keep jnp.ndarray for older
-    return isinstance(x, (getattr(jax, "Array", ()), getattr(jnp, "ndarray", ())))
+    return isinstance(
+        x, (getattr(jax, "Array", ()), getattr(jnp, "ndarray", ()))
+    )
+
 
 def _is_tf(x: Any) -> bool:
     tf = sys.modules.get("tensorflow")
     return bool(tf) and isinstance(x, (tf.Tensor, tf.Variable))
+
 
 def _is_pandas(x: Any) -> bool:
     pd = sys.modules.get("pandas")
@@ -85,7 +91,7 @@ def _is_tensorflow_model(model: Any) -> bool:
     return bool(keras) and isinstance(model, getattr(keras, "Model", ()))
 
 
-def _contains_jax_arrays(obj: Any, visited: set[int] | None = None) -> bool:
+def _contains_jax_arrays(obj: Any, visited: "set[int] | None" = None) -> bool:
     if visited is None:
         visited = set()
 
@@ -98,14 +104,18 @@ def _contains_jax_arrays(obj: Any, visited: set[int] | None = None) -> bool:
         return True
 
     if isinstance(obj, dict):
-        return any(_contains_jax_arrays(value, visited) for value in obj.values())
+        return any(
+            _contains_jax_arrays(value, visited) for value in obj.values()
+        )
 
     if isinstance(obj, (list, tuple, set, frozenset)):
         return any(_contains_jax_arrays(value, visited) for value in obj)
 
     obj_dict = getattr(obj, "__dict__", None)
     if isinstance(obj_dict, dict):
-        return any(_contains_jax_arrays(value, visited) for value in obj_dict.values())
+        return any(
+            _contains_jax_arrays(value, visited) for value in obj_dict.values()
+        )
 
     return False
 
@@ -228,6 +238,7 @@ def copy_model(model: Any) -> Any:
 # Canonical ops interface
 # -------------------------
 
+
 @runtime_checkable
 class BackendOps(Protocol):
     """Protocol describing backend operations used across the API."""
@@ -272,13 +283,16 @@ class BackendOps(Protocol):
     def scalar_at(self, x: Any, index: int) -> Any: ...
 
     # ordering / indexing (needed for RAPS-like scores, quantiles, bbox sets, etc.)
-    def argsort(self, x: Any, axis: int = -1, descending: bool = False) -> Any: ...
+    def argsort(
+        self, x: Any, axis: int = -1, descending: bool = False
+    ) -> Any: ...
     def take_along_axis(self, arr: Any, indices: Any, axis: int) -> Any: ...
 
 
 # -------------------------
 # Concrete backends
 # -------------------------
+
 
 @dataclass(frozen=True)
 class _NumpyOps:
@@ -297,31 +311,72 @@ class _NumpyOps:
         # accept list-like
         return _np.asarray(x)
 
-    def abs(self, x): return _np.abs(x)
-    def maximum(self, a, b): return _np.maximum(a, b)
-    def minimum(self, a, b): return _np.minimum(a, b)
-    def clip(self, x, a_min, a_max): return _np.clip(x, a_min, a_max)
-    def sqrt(self, x): return _np.sqrt(x)
-    def where(self, cond, x, y): return _np.where(cond, x, y)
-    def any(self, x): return bool(_np.any(x))
+    def abs(self, x):
+        return _np.abs(x)
 
-    def sum(self, x, axis=None, keepdims=False): return _np.sum(x, axis=axis,
-                                                                keepdims=keepdims)
-    def mean(self, x, axis=None, keepdims=False): return _np.mean(x, axis=axis, keepdims=keepdims)
-    def max(self, x, axis=None, keepdims=False): return _np.max(x, axis=axis, keepdims=keepdims)
-    def min(self, x, axis=None, keepdims=False): return _np.min(x, axis=axis, keepdims=keepdims)
-    def cumsum(self, x, axis=0): return _np.cumsum(x, axis=axis)
-    def argmax(self, x, axis=None): return _np.argmax(x, axis=axis)
+    def maximum(self, a, b):
+        return _np.maximum(a, b)
 
-    def reshape(self, x, shape): return _np.reshape(x, shape)
-    def squeeze(self, x, axis=None): return _np.squeeze(x, axis=axis)
-    def concat(self, xs, axis=0): return _np.concatenate(xs, axis=axis)
-    def arange(self, start, stop=None, step=1): return _np.arange(start, stop, step)
-    def full(self, shape, fill_value, dtype=None): return _np.full(shape, fill_value, dtype=dtype)
-    def ones_like(self, x): return _np.ones_like(x)
-    def equal(self, a, b): return _np.equal(a, b)
-    def astype(self, x, dtype): return _np.asarray(x).astype(dtype)
-    def random_uniform(self, shape): return _np.random.uniform(size=shape)
+    def minimum(self, a, b):
+        return _np.minimum(a, b)
+
+    def clip(self, x, a_min, a_max):
+        return _np.clip(x, a_min, a_max)
+
+    def sqrt(self, x):
+        return _np.sqrt(x)
+
+    def where(self, cond, x, y):
+        return _np.where(cond, x, y)
+
+    def any(self, x):
+        return bool(_np.any(x))
+
+    def sum(self, x, axis=None, keepdims=False):
+        return _np.sum(x, axis=axis, keepdims=keepdims)
+
+    def mean(self, x, axis=None, keepdims=False):
+        return _np.mean(x, axis=axis, keepdims=keepdims)
+
+    def max(self, x, axis=None, keepdims=False):
+        return _np.max(x, axis=axis, keepdims=keepdims)
+
+    def min(self, x, axis=None, keepdims=False):
+        return _np.min(x, axis=axis, keepdims=keepdims)
+
+    def cumsum(self, x, axis=0):
+        return _np.cumsum(x, axis=axis)
+
+    def argmax(self, x, axis=None):
+        return _np.argmax(x, axis=axis)
+
+    def reshape(self, x, shape):
+        return _np.reshape(x, shape)
+
+    def squeeze(self, x, axis=None):
+        return _np.squeeze(x, axis=axis)
+
+    def concat(self, xs, axis=0):
+        return _np.concatenate(xs, axis=axis)
+
+    def arange(self, start, stop=None, step=1):
+        return _np.arange(start, stop, step)
+
+    def full(self, shape, fill_value, dtype=None):
+        return _np.full(shape, fill_value, dtype=dtype)
+
+    def ones_like(self, x):
+        return _np.ones_like(x)
+
+    def equal(self, a, b):
+        return _np.equal(a, b)
+
+    def astype(self, x, dtype):
+        return _np.asarray(x).astype(dtype)
+
+    def random_uniform(self, shape):
+        return _np.random.uniform(size=shape)
+
     def scalar_at(self, x, index):
         return _np.asarray(x).reshape(-1)[index].item()
 
@@ -341,10 +396,15 @@ class _PandasOps:
 
     def asarray(self, x: Any):
         import pandas as pd
+
         if isinstance(x, (pd.DataFrame, pd.Series, pd.Index)):
             return x
         # Heuristique minimale
-        if isinstance(x, (list, tuple)) and len(x) > 0 and isinstance(x[0], (list, tuple, dict)):
+        if (
+            isinstance(x, (list, tuple))
+            and len(x) > 0
+            and isinstance(x[0], (list, tuple, dict))
+        ):
             return pd.DataFrame(x)
         return pd.Series(x)
 
@@ -360,8 +420,10 @@ class _PandasOps:
         return x.abs() if hasattr(x, "abs") else _np.abs(self.to_numpy(x))
 
     def maximum(self, a, b):
-        a = self.asarray(a); b = self.asarray(b)
+        a = self.asarray(a)
+        b = self.asarray(b)
         import pandas as pd
+
         if isinstance(a, pd.DataFrame) and isinstance(b, pd.DataFrame):
             return a.where(a >= b, b)
         if isinstance(a, pd.Series) and isinstance(b, pd.Series):
@@ -371,8 +433,10 @@ class _PandasOps:
         return self._wrap_like(a, out)
 
     def minimum(self, a, b):
-        a = self.asarray(a); b = self.asarray(b)
+        a = self.asarray(a)
+        b = self.asarray(b)
         import pandas as pd
+
         if isinstance(a, pd.DataFrame) and isinstance(b, pd.DataFrame):
             return a.where(a <= b, b)
         if isinstance(a, pd.Series) and isinstance(b, pd.Series):
@@ -397,19 +461,38 @@ class _PandasOps:
         return self._wrap_like(x, out)
 
     def where(self, cond, x, y):
-        x = self.asarray(x); y = self.asarray(y)
+        x = self.asarray(x)
+        y = self.asarray(y)
         import pandas as pd
+
         if isinstance(x, pd.DataFrame):
             cond = self.asarray(cond)
             if isinstance(cond, pd.DataFrame):
                 cond = cond.reindex(index=x.index, columns=x.columns)
-            return x.where(cond, other=y if isinstance(y, pd.DataFrame) else self._wrap_like(x, self.to_numpy(y)))
+            return x.where(
+                cond,
+                other=(
+                    y
+                    if isinstance(y, pd.DataFrame)
+                    else self._wrap_like(x, self.to_numpy(y))
+                ),
+            )
         if isinstance(x, pd.Series):
             cond = self.asarray(cond)
             if isinstance(cond, pd.Series):
                 cond = cond.reindex(x.index)
-            return x.where(cond, other=y if isinstance(y, pd.Series) else self._wrap_like(x, self.to_numpy(y)))
-        return _np.where(self.to_numpy(cond), self.to_numpy(x), self.to_numpy(y))
+            return x.where(
+                cond,
+                other=(
+                    y
+                    if isinstance(y, pd.Series)
+                    else self._wrap_like(x, self.to_numpy(y))
+                ),
+            )
+        return _np.where(
+            self.to_numpy(cond), self.to_numpy(x), self.to_numpy(y)
+        )
+
     def any(self, x):
         return bool(_np.any(self.to_numpy(self.asarray(x))))
 
@@ -433,6 +516,7 @@ class _PandasOps:
         x = self.asarray(x)
         out = x.min(axis=axis)
         return self._keepdims(x, out, axis) if keepdims else out
+
     def cumsum(self, x, axis=0):
         x = self.asarray(x)
         if hasattr(x, "cumsum"):
@@ -441,6 +525,7 @@ class _PandasOps:
             except Exception:
                 pass
         return self._wrap_like(x, _np.cumsum(self.to_numpy(x), axis=axis))
+
     def argmax(self, x, axis=None):
         return _np.argmax(self.to_numpy(self.asarray(x)), axis=axis)
 
@@ -451,9 +536,16 @@ class _PandasOps:
         x = self.asarray(x)
         out = self.to_numpy(x).reshape(shape)
         if len(shape) != 2:
-            raise ValueError("pandas backend supports reshape only to 2D (DataFrame).")
+            raise ValueError(
+                "pandas backend supports reshape only to 2D (DataFrame)."
+            )
         import pandas as pd
-        idx = x.index if hasattr(x, "index") and shape[0] == len(x.index) else None
+
+        idx = (
+            x.index
+            if hasattr(x, "index") and shape[0] == len(x.index)
+            else None
+        )
         return pd.DataFrame(out, index=idx)
 
     def squeeze(self, x, axis=None):
@@ -461,34 +553,46 @@ class _PandasOps:
         x = self.asarray(x)
         out = _np.squeeze(self.to_numpy(x), axis=axis)
         return self._wrap_like(x, out)
+
     def concat(self, xs, axis=0):
         import pandas as pd
 
         if len(xs) == 0:
-            raise ValueError("concat requires at least one array to concatenate.")
+            raise ValueError(
+                "concat requires at least one array to concatenate."
+            )
         if all(isinstance(x, (pd.DataFrame, pd.Series, pd.Index)) for x in xs):
             return pd.concat(xs, axis=axis)
 
-        out = _np.concatenate([self.to_numpy(self.asarray(x)) for x in xs], axis=axis)
+        out = _np.concatenate(
+            [self.to_numpy(self.asarray(x)) for x in xs], axis=axis
+        )
         return self._wrap_like(self.asarray(xs[0]), out)
-    def arange(self, start, stop=None, step=1): return _np.arange(start, stop, step)
+
+    def arange(self, start, stop=None, step=1):
+        return _np.arange(start, stop, step)
+
     def full(self, shape, fill_value, dtype=None):
         out = _np.full(shape, fill_value, dtype=dtype)
         import pandas as pd
+
         if len(shape) == 1:
             return pd.Series(out)
         if len(shape) == 2:
             return pd.DataFrame(out)
         return out
+
     def ones_like(self, x):
         x = self.asarray(x)
         out = _np.ones_like(self.to_numpy(x))
         return self._wrap_like(x, out)
+
     def equal(self, a, b):
         a = self.asarray(a)
         b = self.asarray(b)
         out = _np.equal(self.to_numpy(a), self.to_numpy(b))
         return self._wrap_like(a, out)
+
     def astype(self, x, dtype):
         x = self.asarray(x)
         if hasattr(x, "astype"):
@@ -497,9 +601,16 @@ class _PandasOps:
             except Exception:
                 pass
         return self._wrap_like(x, self.to_numpy(x).astype(dtype))
-    def random_uniform(self, shape): return _np.random.uniform(size=shape)
+
+    def random_uniform(self, shape):
+        return _np.random.uniform(size=shape)
+
     def scalar_at(self, x, index):
-        return _np.asarray(self.to_numpy(self.asarray(x))).reshape(-1)[index].item()
+        return (
+            _np.asarray(self.to_numpy(self.asarray(x)))
+            .reshape(-1)[index]
+            .item()
+        )
 
     # ---------- ordering / indexing ----------
     def argsort(self, x, axis=-1, descending=False):
@@ -514,9 +625,12 @@ class _PandasOps:
         # This operation breaks the semantics of columns if axis=1 with row-wise indices.
         # We return DataFrame/Series with preserved index, columns RangeIndex.
         import pandas as pd
+
         arr = self.asarray(arr)
         ind = self.asarray(indices)
-        out = _np.take_along_axis(self.to_numpy(arr), self.to_numpy(ind), axis=axis)
+        out = _np.take_along_axis(
+            self.to_numpy(arr), self.to_numpy(ind), axis=axis
+        )
 
         if isinstance(arr, pd.DataFrame):
             if out.ndim == 2:
@@ -533,6 +647,7 @@ class _PandasOps:
     # ---------- helpers ----------
     def _wrap_like(self, ref, out: _np.ndarray):
         import pandas as pd
+
         out = _np.asarray(out)
 
         if isinstance(ref, pd.DataFrame):
@@ -552,12 +667,17 @@ class _PandasOps:
             return pd.Series(out) if out.ndim == 1 else pd.DataFrame(out)
 
         if isinstance(ref, pd.Index):
-            return pd.Index(out, name=ref.name) if out.ndim == 1 else pd.DataFrame(out)
+            return (
+                pd.Index(out, name=ref.name)
+                if out.ndim == 1
+                else pd.DataFrame(out)
+            )
 
         return out
 
     def _keepdims(self, ref, reduced, axis):
         import pandas as pd
+
         if isinstance(ref, pd.DataFrame) and isinstance(reduced, pd.Series):
             if axis in (None, 0, "index"):
                 return reduced.to_frame().T
@@ -567,6 +687,7 @@ class _PandasOps:
             return pd.Series([reduced], name=ref.name)
         return reduced
 
+
 @dataclass(frozen=True)
 class _TorchOps:
     name: str = "torch"
@@ -574,6 +695,7 @@ class _TorchOps:
     @property
     def _torch(self):
         import torch
+
         return torch
 
     def asarray(self, x: Any):
@@ -592,29 +714,48 @@ class _TorchOps:
             return x.to_numpy()
         return _np.asarray(x)
 
-    def abs(self, x): return self._torch.abs(x)
-    def maximum(self, a, b): return self._torch.maximum(a, b)
-    def minimum(self, a, b): return self._torch.minimum(a, b)
-    def clip(self, x, a_min, a_max): return self._torch.clamp(x, min=a_min, max=a_max)
-    def sqrt(self, x): return self._torch.sqrt(x)
-    def where(self, cond, x, y): return self._torch.where(cond, x, y)
-    def any(self, x): return bool(self._torch.any(x).item())
+    def abs(self, x):
+        return self._torch.abs(x)
+
+    def maximum(self, a, b):
+        return self._torch.maximum(a, b)
+
+    def minimum(self, a, b):
+        return self._torch.minimum(a, b)
+
+    def clip(self, x, a_min, a_max):
+        return self._torch.clamp(x, min=a_min, max=a_max)
+
+    def sqrt(self, x):
+        return self._torch.sqrt(x)
+
+    def where(self, cond, x, y):
+        return self._torch.where(cond, x, y)
+
+    def any(self, x):
+        return bool(self._torch.any(x).item())
 
     def sum(self, x, axis=None, keepdims=False):
         return self._torch.sum(x, dim=axis, keepdim=keepdims)
+
     def mean(self, x, axis=None, keepdims=False):
         return self._torch.mean(x, dim=axis, keepdim=keepdims)
+
     def max(self, x, axis=None, keepdims=False):
         if axis is None:
             return self._torch.max(x)
         v, _ = self._torch.max(x, dim=axis, keepdim=keepdims)
         return v
+
     def min(self, x, axis=None, keepdims=False):
         if axis is None:
             return self._torch.min(x)
         v, _ = self._torch.min(x, dim=axis, keepdim=keepdims)
         return v
-    def cumsum(self, x, axis=0): return self._torch.cumsum(x, dim=axis)
+
+    def cumsum(self, x, axis=0):
+        return self._torch.cumsum(x, dim=axis)
+
     def argmax(self, x, axis=None):
         if hasattr(x, "dtype") and x.dtype == self._torch.bool:
             x = x.to(dtype=self._torch.int64)
@@ -622,13 +763,20 @@ class _TorchOps:
             return self._torch.argmax(x)
         return self._torch.argmax(x, dim=axis)
 
-    def reshape(self, x, shape): return x.reshape(shape)
-    def squeeze(self, x, axis=None): return x.squeeze(dim=axis) if axis is not None else x.squeeze()
-    def concat(self, xs, axis=0): return self._torch.cat(xs, dim=axis)
+    def reshape(self, x, shape):
+        return x.reshape(shape)
+
+    def squeeze(self, x, axis=None):
+        return x.squeeze(dim=axis) if axis is not None else x.squeeze()
+
+    def concat(self, xs, axis=0):
+        return self._torch.cat(xs, dim=axis)
+
     def arange(self, start, stop=None, step=1):
         if stop is None:
             return self._torch.arange(start)
         return self._torch.arange(start, stop, step)
+
     def full(self, shape, fill_value, dtype=None):
         kwargs = {}
         if dtype is not None:
@@ -639,8 +787,13 @@ class _TorchOps:
                 raise TypeError(f"Unsupported torch dtype: {dtype}")
             kwargs["dtype"] = torch_dtype
         return self._torch.full(shape, fill_value, **kwargs)
-    def ones_like(self, x): return self._torch.ones_like(x)
-    def equal(self, a, b): return self._torch.eq(a, b)
+
+    def ones_like(self, x):
+        return self._torch.ones_like(x)
+
+    def equal(self, a, b):
+        return self._torch.eq(a, b)
+
     def astype(self, x, dtype):
         torch_dtype = getattr(self._torch, str(dtype), None)
         if torch_dtype is None:
@@ -648,7 +801,10 @@ class _TorchOps:
         if torch_dtype is None:
             raise TypeError(f"Unsupported torch dtype: {dtype}")
         return x.to(dtype=torch_dtype)
-    def random_uniform(self, shape): return self._torch.rand(shape)
+
+    def random_uniform(self, shape):
+        return self._torch.rand(shape)
+
     def scalar_at(self, x, index):
         return self.asarray(x).reshape(-1)[index].item()
 
@@ -667,6 +823,7 @@ class _JaxOps:
     @property
     def _jnp(self):
         import jax.numpy as jnp
+
         return jnp
 
     def asarray(self, x: Any):
@@ -677,30 +834,72 @@ class _JaxOps:
     def to_numpy(self, x: Any) -> _np.ndarray:
         return _np.asarray(x)
 
-    def abs(self, x): return self._jnp.abs(x)
-    def maximum(self, a, b): return self._jnp.maximum(a, b)
-    def minimum(self, a, b): return self._jnp.minimum(a, b)
-    def clip(self, x, a_min, a_max): return self._jnp.clip(x, a_min, a_max)
-    def sqrt(self, x): return self._jnp.sqrt(x)
-    def where(self, cond, x, y): return self._jnp.where(cond, x, y)
-    def any(self, x): return bool(_np.asarray(self._jnp.any(x)))
+    def abs(self, x):
+        return self._jnp.abs(x)
 
-    def sum(self, x, axis=None, keepdims=False): return self._jnp.sum(x, axis=axis, keepdims=keepdims)
-    def mean(self, x, axis=None, keepdims=False): return self._jnp.mean(x, axis=axis, keepdims=keepdims)
-    def max(self, x, axis=None, keepdims=False): return self._jnp.max(x, axis=axis, keepdims=keepdims)
-    def min(self, x, axis=None, keepdims=False): return self._jnp.min(x, axis=axis, keepdims=keepdims)
-    def cumsum(self, x, axis=0): return self._jnp.cumsum(x, axis=axis)
-    def argmax(self, x, axis=None): return self._jnp.argmax(x, axis=axis)
+    def maximum(self, a, b):
+        return self._jnp.maximum(a, b)
 
-    def reshape(self, x, shape): return self._jnp.reshape(x, shape)
-    def squeeze(self, x, axis=None): return self._jnp.squeeze(x, axis=axis)
-    def concat(self, xs, axis=0): return self._jnp.concatenate(xs, axis=axis)
-    def arange(self, start, stop=None, step=1): return self._jnp.arange(start, stop, step)
-    def full(self, shape, fill_value, dtype=None): return self._jnp.full(shape, fill_value, dtype=dtype)
-    def ones_like(self, x): return self._jnp.ones_like(x)
-    def equal(self, a, b): return self._jnp.equal(a, b)
-    def astype(self, x, dtype): return x.astype(dtype)
-    def random_uniform(self, shape): return self._jnp.asarray(_np.random.uniform(size=shape))
+    def minimum(self, a, b):
+        return self._jnp.minimum(a, b)
+
+    def clip(self, x, a_min, a_max):
+        return self._jnp.clip(x, a_min, a_max)
+
+    def sqrt(self, x):
+        return self._jnp.sqrt(x)
+
+    def where(self, cond, x, y):
+        return self._jnp.where(cond, x, y)
+
+    def any(self, x):
+        return bool(_np.asarray(self._jnp.any(x)))
+
+    def sum(self, x, axis=None, keepdims=False):
+        return self._jnp.sum(x, axis=axis, keepdims=keepdims)
+
+    def mean(self, x, axis=None, keepdims=False):
+        return self._jnp.mean(x, axis=axis, keepdims=keepdims)
+
+    def max(self, x, axis=None, keepdims=False):
+        return self._jnp.max(x, axis=axis, keepdims=keepdims)
+
+    def min(self, x, axis=None, keepdims=False):
+        return self._jnp.min(x, axis=axis, keepdims=keepdims)
+
+    def cumsum(self, x, axis=0):
+        return self._jnp.cumsum(x, axis=axis)
+
+    def argmax(self, x, axis=None):
+        return self._jnp.argmax(x, axis=axis)
+
+    def reshape(self, x, shape):
+        return self._jnp.reshape(x, shape)
+
+    def squeeze(self, x, axis=None):
+        return self._jnp.squeeze(x, axis=axis)
+
+    def concat(self, xs, axis=0):
+        return self._jnp.concatenate(xs, axis=axis)
+
+    def arange(self, start, stop=None, step=1):
+        return self._jnp.arange(start, stop, step)
+
+    def full(self, shape, fill_value, dtype=None):
+        return self._jnp.full(shape, fill_value, dtype=dtype)
+
+    def ones_like(self, x):
+        return self._jnp.ones_like(x)
+
+    def equal(self, a, b):
+        return self._jnp.equal(a, b)
+
+    def astype(self, x, dtype):
+        return x.astype(dtype)
+
+    def random_uniform(self, shape):
+        return self._jnp.asarray(_np.random.uniform(size=shape))
+
     def scalar_at(self, x, index):
         return _np.asarray(self.asarray(x).reshape(-1)[index]).item()
 
@@ -721,6 +920,7 @@ class _TensorflowOps:
     @property
     def _tf(self):
         import tensorflow as tf
+
         return tf
 
     def asarray(self, x: Any):
@@ -739,39 +939,78 @@ class _TensorflowOps:
             return x.to_numpy()
         return _np.asarray(x)
 
-    def abs(self, x): return self._tf.abs(x)
-    def maximum(self, a, b): return self._tf.maximum(a, b)
-    def minimum(self, a, b): return self._tf.minimum(a, b)
-    def clip(self, x, a_min, a_max): return self._tf.clip_by_value(x, a_min, a_max)
-    def sqrt(self, x): return self._tf.sqrt(x)
-    def where(self, cond, x, y): return self._tf.where(cond, x, y)
-    def any(self, x): return bool(self.to_numpy(self._tf.reduce_any(x)))
+    def abs(self, x):
+        return self._tf.abs(x)
+
+    def maximum(self, a, b):
+        return self._tf.maximum(a, b)
+
+    def minimum(self, a, b):
+        return self._tf.minimum(a, b)
+
+    def clip(self, x, a_min, a_max):
+        return self._tf.clip_by_value(x, a_min, a_max)
+
+    def sqrt(self, x):
+        return self._tf.sqrt(x)
+
+    def where(self, cond, x, y):
+        return self._tf.where(cond, x, y)
+
+    def any(self, x):
+        return bool(self.to_numpy(self._tf.reduce_any(x)))
 
     # TF reduction names differ -> normalize here
-    def sum(self, x, axis=None, keepdims=False): return self._tf.reduce_sum(x, axis=axis, keepdims=keepdims)
-    def mean(self, x, axis=None, keepdims=False): return self._tf.reduce_mean(x, axis=axis, keepdims=keepdims)
-    def max(self, x, axis=None, keepdims=False): return self._tf.reduce_max(x, axis=axis, keepdims=keepdims)
-    def min(self, x, axis=None, keepdims=False): return self._tf.reduce_min(x, axis=axis, keepdims=keepdims)
-    def cumsum(self, x, axis=0): return self._tf.cumsum(x, axis=axis)
+    def sum(self, x, axis=None, keepdims=False):
+        return self._tf.reduce_sum(x, axis=axis, keepdims=keepdims)
+
+    def mean(self, x, axis=None, keepdims=False):
+        return self._tf.reduce_mean(x, axis=axis, keepdims=keepdims)
+
+    def max(self, x, axis=None, keepdims=False):
+        return self._tf.reduce_max(x, axis=axis, keepdims=keepdims)
+
+    def min(self, x, axis=None, keepdims=False):
+        return self._tf.reduce_min(x, axis=axis, keepdims=keepdims)
+
+    def cumsum(self, x, axis=0):
+        return self._tf.cumsum(x, axis=axis)
+
     def argmax(self, x, axis=None):
         return self._tf.argmax(x, axis=axis, output_type=self._tf.int64)
 
-    def reshape(self, x, shape): return self._tf.reshape(x, shape)
-    def squeeze(self, x, axis=None): return self._tf.squeeze(x, axis=axis)
-    def concat(self, xs, axis=0): return self._tf.concat(xs, axis=axis)
+    def reshape(self, x, shape):
+        return self._tf.reshape(x, shape)
+
+    def squeeze(self, x, axis=None):
+        return self._tf.squeeze(x, axis=axis)
+
+    def concat(self, xs, axis=0):
+        return self._tf.concat(xs, axis=axis)
+
     def arange(self, start, stop=None, step=1):
         if stop is None:
             return self._tf.range(start)
         return self._tf.range(start, limit=stop, delta=step)
+
     def full(self, shape, fill_value, dtype=None):
         out = self._tf.fill(shape, fill_value)
         if dtype is not None:
             out = self._tf.cast(out, self._tf.as_dtype(dtype))
         return out
-    def ones_like(self, x): return self._tf.ones_like(x)
-    def equal(self, a, b): return self._tf.equal(a, b)
-    def astype(self, x, dtype): return self._tf.cast(x, self._tf.as_dtype(dtype))
-    def random_uniform(self, shape): return self._tf.random.uniform(shape)
+
+    def ones_like(self, x):
+        return self._tf.ones_like(x)
+
+    def equal(self, a, b):
+        return self._tf.equal(a, b)
+
+    def astype(self, x, dtype):
+        return self._tf.cast(x, self._tf.as_dtype(dtype))
+
+    def random_uniform(self, shape):
+        return self._tf.random.uniform(shape)
+
     def scalar_at(self, x, index):
         flat = self._tf.reshape(self.asarray(x), (-1,))
         return self.to_numpy(flat[index]).item()
@@ -787,7 +1026,9 @@ class _TensorflowOps:
         # Move axis to last for gather, then invert permutation
         rank = tf.rank(arr)
         axis_ = axis if axis >= 0 else axis + arr.shape.rank
-        perm = tf.concat([tf.range(axis_), tf.range(axis_ + 1, rank), [axis_]], axis=0)
+        perm = tf.concat(
+            [tf.range(axis_), tf.range(axis_ + 1, rank), [axis_]], axis=0
+        )
         inv = tf.argsort(perm)
         a = tf.transpose(arr, perm)
         ind = tf.transpose(indices, perm)
@@ -850,7 +1091,9 @@ def shape2(x: Any) -> Tuple[int, Tuple[int, ...]]:
         return arr.ndim, arr.shape
 
 
-def split_columns(x: Any, columns: Sequence[int], *, keepdims: bool = False) -> Tuple[Any, ...]:
+def split_columns(
+    x: Any, columns: Sequence[int], *, keepdims: bool = False
+) -> Tuple[Any, ...]:
     """Extract selected columns from a 2D backend object.
 
     :param Any x: backend array/tensor/dataframe with shape ``(n, d)``.
@@ -896,18 +1139,22 @@ def concat_columns(cols: Sequence[Any], *, like: Any) -> Any:
 
     if b.name == "torch":
         import torch
+
         return torch.cat(cols, dim=1)
 
     if b.name == "tensorflow":
         import tensorflow as tf
+
         return tf.concat(cols, axis=1)
 
     if b.name == "jax":
         import jax.numpy as jnp
+
         return jnp.concatenate(cols, axis=1)
 
     if b.name == "pandas":
         import pandas as pd
+
         return pd.concat(cols, axis=1)
 
     return _np.concatenate(cols, axis=1)

--- a/deel/puncc/api/experimental.py
+++ b/deel/puncc/api/experimental.py
@@ -23,106 +23,91 @@
 """
 This module provides experimental features. Use cautiously.
 """
-import importlib.util
 
-if importlib.util.find_spec("torch") is not None:
-    import torch
+import torch
+from deel.puncc.api.backend import copy_model
 
-    class TorchPredictor:
-        """Wrapper of a torch prediction model :math:`\hat{f}`. Enables to
-        standardize the interface of torch predictors and to expose generic :func:`fit`,
-        :func:`predict` and :func:`copy` methods.
 
-        :param Any model: torch prediction model :math:`\hat{f}`
-        :param bool is_trained: boolean flag that informs if the model is
-            pre-trained. If True, the call to :func:`fit` will be skipped
-        :param torch.optim.Optimizer optimizer: torch optimizer.
-            Defaults to `torch.optim.Adam`.
-        :param torch.nn.modules.loss criterion: criterion that measures the distance
-            between predictions and outputs. Default to  `torch.nn.MSELoss`.
-        :param compile_kwargs: keyword arguments to be used if needed during the
-            call :func:`model.compile` on the underlying model
+class TorchPredictor:
+    """Wrapper of a torch prediction model :math:`\hat{f}`. Enables to
+    standardize the interface of torch predictors and to expose generic :func:`fit`,
+    :func:`predict` and :func:`copy` methods.
 
-        .. note::
+    :param Any model: torch prediction model :math:`\hat{f}`
+    :param bool is_trained: boolean flag that informs if the model is
+        pre-trained. If True, the call to :func:`fit` will be skipped
+    :param torch.optim.Optimizer optimizer: torch optimizer.
+        Defaults to `torch.optim.Adam`.
+    :param torch.nn.modules.loss criterion: criterion that measures the distance
+        between predictions and outputs. Default to  `torch.nn.MSELoss`.
+    :param compile_kwargs: keyword arguments to be used if needed during the
+        call :func:`model.compile` on the underlying model
 
-            The `model` constructor has to take as argument both
-            `input_feat`:int and `output_feat`:int, corresponding to the number
-            of features (or channels) for each input and output, respectively.
+    """
+
+    def __init__(
+        self,
+        model,
+        is_trained=False,
+        optimizer=torch.optim.Adam,
+        criterion=torch.nn.MSELoss(reduction="sum"),
+        **compile_kwargs,
+    ):
+        self.model = model
+        self.is_trained = is_trained
+        self.compile_kwargs = compile_kwargs
+        self.optimizer = optimizer
+        self.criterion = criterion
+
+    def fit(self, X, y, **kwargs):
+        """Fit model to the training data.
+
+        :param torch.Tensor X: train features.
+        :param torch.Tensor y: train labels.
+        :param kwargs: keyword arguments to configure the training.
 
         """
+        if "epochs" in kwargs.keys():
+            epochs = kwargs["epochs"]
+        else:
+            epochs = 1
 
-        def __init__(
-            self,
-            model,
-            is_trained=False,
-            optimizer=torch.optim.Adam,
-            criterion=torch.nn.MSELoss(reduction="sum"),
-            **compile_kwargs,
-        ):
-            self.model = model
-            self.is_trained = is_trained
-            self.compile_kwargs = compile_kwargs
-            self.optimizer = optimizer
-            self.criterion = criterion
+        optimizer = self.optimizer(
+            self.model.parameters(), **self.compile_kwargs
+        )
+        for _ in range(epochs):
+            y_pred = self.model(X)
+            loss = self.criterion(y_pred, y)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
 
-        def fit(self, X, y, **kwargs):
-            """Fit model to the training data.
+    def predict(self, X):
+        """Compute predictions on new examples.
 
-            :param torch.Tensor X: train features.
-            :param torch.Tensor y: train labels.
-            :param kwargs: keyword arguments to configure the training.
+        :param torch.Tensor X: new examples' features.
 
-            """
-            if "epochs" in kwargs.keys():
-                epochs = kwargs["epochs"]
-            else:
-                epochs = 1
+        :returns: predictions :math:`\hat{f}(X)` associated to the new
+            examples X.
+        :rtype: torch.Tensor
 
-            optimizer = self.optimizer(
-                self.model.parameters(), **self.compile_kwargs
-            )
-            for _ in range(epochs):
-                y_pred = self.model(X)
-                loss = self.criterion(y_pred, y)
-                optimizer.zero_grad()
-                loss.backward()
-                optimizer.step()
+        """
+        return self.model(X)
 
-        def predict(self, X):
-            """Compute predictions on new examples.
+    def copy(self):
+        """Returns a copy of the predictor.
 
-            :param torch.Tensor X: new examples' features.
+        :returns: copy of the predictor.
+        :rtype: TorchPredictor
 
-            :returns: predictions :math:`\hat{f}(X)` associated to the new
-                examples X.
-            :rtype: torch.Tensor
+        """
+        model = copy_model(self.model)
+        predictor_copy = TorchPredictor(
+            model=model,
+            is_trained=self.is_trained,
+            optimizer=self.optimizer,
+            criterion=self.criterion,
+            **self.compile_kwargs,
+        )
 
-            """
-            return self.model(X)
-
-        def copy(self):
-            """Returns a copy of the predictor.
-
-            :returns: copy of the predictor.
-            :rtype: TorchPredictor
-
-            """
-            input_feat = (
-                (self.model.state_dict()).popitem(last=False)[1].shape[-1]
-            )
-            output_feat = (
-                (self.model.state_dict()).popitem(last=True)[1].shape[-1]
-            )
-            model = type(self.model)(
-                input_feat=input_feat, output_feat=output_feat
-            )
-            model.load_state_dict(self.model.state_dict())
-            predictor_copy = TorchPredictor(
-                model=model,
-                is_trained=self.is_trained,
-                optimizer=self.optimizer,
-                criterion=self.criterion,
-                **self.compile_kwargs,
-            )
-
-            return predictor_copy
+        return predictor_copy

--- a/deel/puncc/api/experimental.py
+++ b/deel/puncc/api/experimental.py
@@ -53,12 +53,18 @@ class TorchPredictor:
         self,
         model,
         is_trained=False,
-        optimizer=torch.optim.Adam,
-        criterion=torch.nn.MSELoss(reduction="sum"),
+        optimizer=None,
+        criterion=None,
         **compile_kwargs,
     ):
         if torch is None:  # pragma: no cover
             raise ImportError("TorchPredictor requires torch to be installed.")
+
+        if optimizer is None:  # pragma: no cover
+            optimizer = torch.optim.Adam
+        if criterion is None:  # pragma: no cover
+            criterion = torch.nn.MSELoss(reduction="sum")
+
         self.model = model
         self.is_trained = is_trained
         self.compile_kwargs = compile_kwargs

--- a/deel/puncc/api/experimental.py
+++ b/deel/puncc/api/experimental.py
@@ -99,8 +99,13 @@ class TorchPredictor:
         :rtype: torch.Tensor
 
         """
+        was_training = self.model.training
         self.model.eval()
-        return self.model(X)
+        try:
+            with torch.no_grad():
+                return self.model(X)
+        finally:
+            self.model.train(was_training)
 
     def copy(self):
         """Returns a copy of the predictor.

--- a/deel/puncc/api/experimental.py
+++ b/deel/puncc/api/experimental.py
@@ -24,8 +24,15 @@
 This module provides experimental features. Use cautiously.
 """
 
-import torch
 from deel.puncc.api.backend import copy_model
+
+try:
+    import torch
+except ImportError as exc:
+    raise ImportError(
+        "Experimental module requires torch to be installed. "
+        "Please install torch to use this module."
+    ) from exc
 
 
 class TorchPredictor:
@@ -40,8 +47,8 @@ class TorchPredictor:
         Defaults to `torch.optim.Adam`.
     :param torch.nn.modules.loss criterion: criterion that measures the distance
         between predictions and outputs. Default to  `torch.nn.MSELoss`.
-    :param compile_kwargs: keyword arguments to be used if needed during the
-        call :func:`model.compile` on the underlying model
+    :param compile_kwargs: keyword arguments passed to the optimizer
+        constructor when creating the optimizer in :func:`fit`.
 
     """
 
@@ -92,6 +99,7 @@ class TorchPredictor:
         :rtype: torch.Tensor
 
         """
+        self.model.eval()
         return self.model(X)
 
     def copy(self):

--- a/deel/puncc/api/experimental.py
+++ b/deel/puncc/api/experimental.py
@@ -28,11 +28,8 @@ from deel.puncc.api.backend import copy_model
 
 try:
     import torch
-except ImportError as exc:
-    raise ImportError(
-        "Experimental module requires torch to be installed. "
-        "Please install torch to use this module."
-    ) from exc
+except ImportError:  # pragma: no cover
+    torch = None
 
 
 class TorchPredictor:
@@ -60,6 +57,8 @@ class TorchPredictor:
         criterion=torch.nn.MSELoss(reduction="sum"),
         **compile_kwargs,
     ):
+        if torch is None:  # pragma: no cover
+            raise ImportError("TorchPredictor requires torch to be installed.")
         self.model = model
         self.is_trained = is_trained
         self.compile_kwargs = compile_kwargs
@@ -74,20 +73,25 @@ class TorchPredictor:
         :param kwargs: keyword arguments to configure the training.
 
         """
-        if "epochs" in kwargs.keys():
-            epochs = kwargs["epochs"]
-        else:
-            epochs = 1
+        was_training = self.model.training
+        self.model.train()
+        try:
+            if "epochs" in kwargs.keys():
+                epochs = kwargs["epochs"]
+            else:
+                epochs = 1
 
-        optimizer = self.optimizer(
-            self.model.parameters(), **self.compile_kwargs
-        )
-        for _ in range(epochs):
-            y_pred = self.model(X)
-            loss = self.criterion(y_pred, y)
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
+            optimizer = self.optimizer(
+                self.model.parameters(), **self.compile_kwargs
+            )
+            for _ in range(epochs):
+                y_pred = self.model(X)
+                loss = self.criterion(y_pred, y)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+        finally:
+            self.model.train(was_training)
 
     def predict(self, X):
         """Compute predictions on new examples.

--- a/deel/puncc/api/prediction.py
+++ b/deel/puncc/api/prediction.py
@@ -23,9 +23,7 @@
 """
 This module provides standard wrappings for ML models.
 """
-import importlib
-from copy import deepcopy
-import copy as _copy
+
 from typing import Any
 from typing import Iterable
 from typing import List
@@ -35,11 +33,9 @@ from typing import Tuple
 import numpy as np
 
 from deel.puncc.api import nonconformity_scores
+from deel.puncc.api.backend import copy_model
 from deel.puncc.api.utils import dual_predictor_check
 from deel.puncc.api.utils import supported_types_check
-
-if importlib.util.find_spec("tensorflow") is not None:
-    import tensorflow as tf
 
 
 class BasePredictor:
@@ -180,8 +176,7 @@ class BasePredictor:
         return np.squeeze(self.model.predict(X, **kwargs))
 
     def copy(self):
-        """Returns a copy of the predictor. The underlying model is either
-        cloned (Keras model) or deepcopied (sklearn and similar models).
+        """Returns a copy of the predictor.
 
         :returns: copy of the predictor.
         :rtype: BasePredictor
@@ -189,22 +184,7 @@ class BasePredictor:
         :raises RuntimeError: copy unsupported for provided models.
 
         """
-
-        model_type_str = str(type(self.model))
-
-        if (
-            "tensorflow" in model_type_str
-            or "keras" in model_type_str
-            and importlib.util.find_spec("tensorflow") is not None
-        ):
-            # pylint: disable=E1101
-            model = tf.keras.models.clone_model(self.model)
-            try:
-                model.set_weights(self.model.get_weights())
-            except Exception:
-                pass
-        else:
-            model = deepcopy(self.model)
+        model = copy_model(self.model)
 
         predictor_copy = self.__class__(
             model=model, is_trained=self.is_trained, **self.compile_kwargs
@@ -474,8 +454,7 @@ class DualPredictor:
         return np.squeeze(Y_pred)
 
     def copy(self):
-        """Returns a copy of the predictor. The underlying models are either
-        cloned (Keras model) or deepcopied (sklearn and similar models).
+        """Returns a copy of the predictor.
 
         :returns: copy of the predictor.
         :rtype: DualPredictor
@@ -485,22 +464,7 @@ class DualPredictor:
         """
         models_copy = []
         for model in self.models:
-            try:
-                model_copy = deepcopy(model)
-            except Exception as e_outer:
-                if importlib.util.find_spec("tensorflow") is not None:
-                    try:
-                        # pylint: disable=E1101
-                        model_copy = tf.keras.models.clone_model(model)
-                    except Exception as e_inner:
-                        msg = (
-                            f"Cannot copy models. Many possible reasons:\n"
-                            f" 1- {e_inner} \n 2- {e_outer}"
-                        )
-                        raise RuntimeError(msg)
-                else:
-                    raise Exception(e_outer)
-            models_copy.append(model_copy)
+            models_copy.append(copy_model(model))
 
         predictor_copy = self.__class__(
             models=models_copy,

--- a/docs/source/theory_overview.rst
+++ b/docs/source/theory_overview.rst
@@ -439,7 +439,7 @@ the RAPS algorithm works in two stages:
     #. The prediction set for a test point :math:`X_{new}` is defined as :math:`\widehat{C}_{\alpha}(X_{new})=\big\lbrace (1),\dots,(k)\big\rbrace`, where
     
         .. math::
-            k = \max\big\lbrace i : \widehat{\pi}_{(1)}+\cdots+\widehat{\pi}_{(i)} + \lambda(i-k_{reg}+1) \leq \delta_\alpha\big\rbrace + 1.
+            k = \max\big\lbrace i : \widehat{\pi}_{(1)}+\cdots+\widehat{\pi}_{(i)} + \lambda(i-k_{reg}+1) < \delta_\alpha\big\rbrace + 1.
 
 
 Classwise Conformal Prediction

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 joblib
 matplotlib
-numpy
+numpy<2.0.0
 pandas
-scikit-learn~=1.3.0
+scikit-learn>=1.5.0
 tqdm

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 flake8
 jax==0.4.30
+numpy<2.0.0
 pandas
 pylint
 pytest
@@ -11,6 +12,6 @@ sphinx-rtd-theme
 sphinx-autodoc-typehints
 sphinxcontrib-bibtex
 tensorflow == 2.11.0
-scikit-learn == 1.3.2
+scikit-learn>=1.5.0
 torch
 tox

--- a/tests/api/test_backend.py
+++ b/tests/api/test_backend.py
@@ -96,27 +96,39 @@ def test_infer_model_backend_generic_default():
     assert infer_model_backend(GenericModel()) == "generic"
 
 
-@pytest.mark.parametrize("name", ["numpy", "pandas", "torch", "tensorflow", "jax"])
+@pytest.mark.parametrize(
+    "name", ["numpy", "pandas", "torch", "tensorflow", "jax"]
+)
 def test_get_backend_name(name):
     x = _make_backend_array(name, [[1.0, 2.0], [3.0, 4.0]])
     b = get_backend(x)
     assert b.name == name
 
 
-@pytest.mark.parametrize("name", ["numpy", "pandas", "torch", "tensorflow", "jax"])
+@pytest.mark.parametrize(
+    "name", ["numpy", "pandas", "torch", "tensorflow", "jax"]
+)
 def test_backend_core_ops(name):
     b = get_backend(_make_backend_array(name, [1.0]))
 
     arr = b.asarray(_make_backend_array(name, [[1.0, -2.0], [3.0, -4.0]]))
-    np.testing.assert_allclose(_to_numpy(b.abs(arr)), np.array([[1.0, 2.0], [3.0, 4.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(b.abs(arr)), np.array([[1.0, 2.0], [3.0, 4.0]])
+    )
 
     a = b.asarray(_make_backend_array(name, [[1.0, 5.0], [2.0, 3.0]]))
     c = b.asarray(_make_backend_array(name, [[2.0, 4.0], [2.0, 6.0]]))
-    np.testing.assert_allclose(_to_numpy(b.maximum(a, c)), np.array([[2.0, 5.0], [2.0, 6.0]]))
-    np.testing.assert_allclose(_to_numpy(b.minimum(a, c)), np.array([[1.0, 4.0], [2.0, 3.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(b.maximum(a, c)), np.array([[2.0, 5.0], [2.0, 6.0]])
+    )
+    np.testing.assert_allclose(
+        _to_numpy(b.minimum(a, c)), np.array([[1.0, 4.0], [2.0, 3.0]])
+    )
 
     clipped = b.clip(a, 1.5, 4.5)
-    np.testing.assert_allclose(_to_numpy(clipped), np.array([[1.5, 4.5], [2.0, 3.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(clipped), np.array([[1.5, 4.5], [2.0, 3.0]])
+    )
 
     sq = b.sqrt(b.asarray(_make_backend_array(name, [1.0, 4.0, 9.0])))
     np.testing.assert_allclose(_to_numpy(sq), np.array([1.0, 2.0, 3.0]))
@@ -126,33 +138,51 @@ def test_backend_core_ops(name):
     np.testing.assert_allclose(_to_numpy(w), np.array([[1.0, 4.0], [2.0, 3.0]]))
     assert b.any(cond)
 
-    np.testing.assert_allclose(_to_numpy(b.sum(a, axis=1)), np.array([6.0, 5.0]))
-    np.testing.assert_allclose(_to_numpy(b.mean(a, axis=0)), np.array([1.5, 4.0]))
-    np.testing.assert_allclose(_to_numpy(b.max(a, axis=0)), np.array([2.0, 5.0]))
-    np.testing.assert_allclose(_to_numpy(b.min(a, axis=0)), np.array([1.0, 3.0]))
+    np.testing.assert_allclose(
+        _to_numpy(b.sum(a, axis=1)), np.array([6.0, 5.0])
+    )
+    np.testing.assert_allclose(
+        _to_numpy(b.mean(a, axis=0)), np.array([1.5, 4.0])
+    )
+    np.testing.assert_allclose(
+        _to_numpy(b.max(a, axis=0)), np.array([2.0, 5.0])
+    )
+    np.testing.assert_allclose(
+        _to_numpy(b.min(a, axis=0)), np.array([1.0, 3.0])
+    )
 
-    cs = b.cumsum(b.asarray(_make_backend_array(name, [[1, 2, 3], [4, 5, 6]])), axis=1)
+    cs = b.cumsum(
+        b.asarray(_make_backend_array(name, [[1, 2, 3], [4, 5, 6]])), axis=1
+    )
     np.testing.assert_allclose(_to_numpy(cs), np.array([[1, 3, 6], [4, 9, 15]]))
 
-    am = b.argmax(b.asarray(_make_backend_array(name, [[1, 9, 3], [4, 2, 8]])), axis=1)
+    am = b.argmax(
+        b.asarray(_make_backend_array(name, [[1, 9, 3], [4, 2, 8]])), axis=1
+    )
     np.testing.assert_allclose(_to_numpy(am), np.array([1, 2]))
 
 
-@pytest.mark.parametrize("name", ["numpy", "pandas", "torch", "tensorflow", "jax"])
+@pytest.mark.parametrize(
+    "name", ["numpy", "pandas", "torch", "tensorflow", "jax"]
+)
 def test_backend_shape_dtype_and_indexing_ops(name):
     b = get_backend(_make_backend_array(name, [1.0]))
 
     arr = b.asarray(_make_backend_array(name, [[10, 20, 30], [40, 50, 60]]))
 
     reshaped = b.reshape(arr, (3, 2))
-    np.testing.assert_allclose(_to_numpy(reshaped), np.array([[10, 20], [30, 40], [50, 60]]))
+    np.testing.assert_allclose(
+        _to_numpy(reshaped), np.array([[10, 20], [30, 40], [50, 60]])
+    )
 
     if name == "pandas":
         with pytest.raises(ValueError):
             b.reshape(arr, (2, 3, 1))
     else:
         squeezed = b.squeeze(b.reshape(arr, (2, 3, 1)))
-        np.testing.assert_allclose(_to_numpy(squeezed), np.array([[10, 20, 30], [40, 50, 60]]))
+        np.testing.assert_allclose(
+            _to_numpy(squeezed), np.array([[10, 20, 30], [40, 50, 60]])
+        )
 
     rng = b.arange(1, 6)
     np.testing.assert_allclose(_to_numpy(rng), np.array([1, 2, 3, 4, 5]))
@@ -161,17 +191,24 @@ def test_backend_shape_dtype_and_indexing_ops(name):
     np.testing.assert_allclose(_to_numpy(full_1d), np.array([7, 7, 7, 7]))
 
     full_2d = b.full((2, 3), -1.5)
-    np.testing.assert_allclose(_to_numpy(full_2d), np.array([[-1.5, -1.5, -1.5], [-1.5, -1.5, -1.5]]))
+    np.testing.assert_allclose(
+        _to_numpy(full_2d), np.array([[-1.5, -1.5, -1.5], [-1.5, -1.5, -1.5]])
+    )
 
     full_dtype = b.full((3,), 2, dtype="int64")
     full_dtype_np = _to_numpy(full_dtype)
-    np.testing.assert_allclose(full_dtype_np, np.array([2, 2, 2], dtype=np.int64))
+    np.testing.assert_allclose(
+        full_dtype_np, np.array([2, 2, 2], dtype=np.int64)
+    )
     if name == "jax":
         assert full_dtype_np.dtype in (np.int32, np.int64)
     else:
         assert full_dtype_np.dtype == np.int64
 
-    eq = b.equal(b.asarray(_make_backend_array(name, [1, 2, 3])), b.asarray(_make_backend_array(name, [1, 0, 3])))
+    eq = b.equal(
+        b.asarray(_make_backend_array(name, [1, 2, 3])),
+        b.asarray(_make_backend_array(name, [1, 0, 3])),
+    )
     np.testing.assert_allclose(_to_numpy(eq), np.array([True, False, True]))
 
     casted = b.astype(b.asarray(_make_backend_array(name, [1.2, 2.8])), "int64")
@@ -182,9 +219,16 @@ def test_backend_shape_dtype_and_indexing_ops(name):
     assert ru_np.shape == (5,)
     assert np.all((ru_np >= 0.0) & (ru_np <= 1.0))
 
-    assert isinstance(b.scalar_at(b.asarray(_make_backend_array(name, [10, 20, 30])), 1), (int, float, np.integer, np.floating))
+    assert isinstance(
+        b.scalar_at(b.asarray(_make_backend_array(name, [10, 20, 30])), 1),
+        (int, float, np.integer, np.floating),
+    )
 
-    idx = b.argsort(b.asarray(_make_backend_array(name, [[3, 1, 2], [5, 4, 6]])), axis=1, descending=False)
+    idx = b.argsort(
+        b.asarray(_make_backend_array(name, [[3, 1, 2], [5, 4, 6]])),
+        axis=1,
+        descending=False,
+    )
     np.testing.assert_allclose(_to_numpy(idx), np.array([[1, 2, 0], [1, 0, 2]]))
 
     ta = b.take_along_axis(
@@ -195,14 +239,18 @@ def test_backend_shape_dtype_and_indexing_ops(name):
     np.testing.assert_allclose(_to_numpy(ta), np.array([[30, 10], [50, 50]]))
 
 
-@pytest.mark.parametrize("name", ["numpy", "pandas", "torch", "tensorflow", "jax"])
+@pytest.mark.parametrize(
+    "name", ["numpy", "pandas", "torch", "tensorflow", "jax"]
+)
 def test_backend_concat_and_ones_like(name):
     b = get_backend(_make_backend_array(name, [1.0]))
 
     left = b.asarray(_make_backend_array(name, [[1.0, 2.0], [3.0, 4.0]]))
     right = b.ones_like(left)
 
-    np.testing.assert_allclose(_to_numpy(right), np.array([[1.0, 1.0], [1.0, 1.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(right), np.array([[1.0, 1.0], [1.0, 1.0]])
+    )
 
     merged = b.concat([left, right], axis=1)
     np.testing.assert_allclose(
@@ -217,7 +265,9 @@ def test_backend_concat_and_ones_like(name):
     )
 
 
-@pytest.mark.parametrize("name", ["numpy", "pandas", "torch", "tensorflow", "jax"])
+@pytest.mark.parametrize(
+    "name", ["numpy", "pandas", "torch", "tensorflow", "jax"]
+)
 def test_shape2_split_concat_helpers(name):
     x = _make_backend_array(name, [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
     b = get_backend(x)
@@ -231,7 +281,10 @@ def test_shape2_split_concat_helpers(name):
     c0, c1, c2, c3 = split_columns(arr, (0, 1, 2, 3), keepdims=True)
     merged = concat_columns([c0, c1, c2, c3], like=arr)
 
-    np.testing.assert_allclose(_to_numpy(merged), np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(merged),
+        np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]),
+    )
 
 
 def test_numpy_backend_accepts_pandas_inputs():
@@ -242,7 +295,9 @@ def test_numpy_backend_accepts_pandas_inputs():
     frame = pd.DataFrame([[1.0, 2.0], [3.0, 4.0]])
     series = pd.Series([5.0, 6.0])
 
-    np.testing.assert_allclose(ops.asarray(frame), np.array([[1.0, 2.0], [3.0, 4.0]]))
+    np.testing.assert_allclose(
+        ops.asarray(frame), np.array([[1.0, 2.0], [3.0, 4.0]])
+    )
     np.testing.assert_allclose(ops.to_numpy(series), np.array([5.0, 6.0]))
     np.testing.assert_allclose(ops.to_numpy([7.0, 8.0]), np.array([7.0, 8.0]))
 
@@ -257,9 +312,15 @@ def test_pandas_backend_special_cases():
     scalar_series = b.asarray([1, 2, 3])
     assert isinstance(scalar_series, pd.Series)
 
-    frame = pd.DataFrame([[1.0, 3.0], [2.0, 4.0]], index=["a", "b"], columns=["x", "y"])
-    cond = pd.DataFrame([[True, False], [False, True]], index=["b", "a"], columns=["y", "x"])
-    other = pd.DataFrame([[10.0, 20.0], [30.0, 40.0]], index=["a", "b"], columns=["x", "y"])
+    frame = pd.DataFrame(
+        [[1.0, 3.0], [2.0, 4.0]], index=["a", "b"], columns=["x", "y"]
+    )
+    cond = pd.DataFrame(
+        [[True, False], [False, True]], index=["b", "a"], columns=["y", "x"]
+    )
+    other = pd.DataFrame(
+        [[10.0, 20.0], [30.0, 40.0]], index=["a", "b"], columns=["x", "y"]
+    )
     where_out = b.where(cond, frame, other)
     assert list(where_out.index) == ["a", "b"]
     assert list(where_out.columns) == ["x", "y"]
@@ -283,13 +344,21 @@ def test_pandas_backend_special_cases():
     assert isinstance(full_3d, np.ndarray)
 
     descending = b.argsort(frame, axis=1, descending=True)
-    np.testing.assert_allclose(_to_numpy(descending), np.array([[1, 0], [1, 0]]))
+    np.testing.assert_allclose(
+        _to_numpy(descending), np.array([[1, 0], [1, 0]])
+    )
 
-    taken_frame = b.take_along_axis(frame, pd.DataFrame([[1], [0]], index=frame.index), axis=1)
+    taken_frame = b.take_along_axis(
+        frame, pd.DataFrame([[1], [0]], index=frame.index), axis=1
+    )
     assert isinstance(taken_frame, pd.DataFrame)
     assert list(taken_frame.index) == ["a", "b"]
 
-    taken_series = b.take_along_axis(pd.Series([9, 7, 8], index=["a", "b", "c"]), pd.Series([2, 0, 1]), axis=0)
+    taken_series = b.take_along_axis(
+        pd.Series([9, 7, 8], index=["a", "b", "c"]),
+        pd.Series([2, 0, 1]),
+        axis=0,
+    )
     assert isinstance(taken_series, pd.Series)
     assert list(taken_series.index) == ["a", "b", "c"]
 
@@ -328,14 +397,20 @@ def test_pandas_backend_fallback_paths():
 
     ops = _PandasOps()
 
-    np.testing.assert_allclose(ops.to_numpy(NoToNumpy()), np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_allclose(
+        ops.to_numpy(NoToNumpy()), np.array([1.0, 2.0, 3.0])
+    )
 
     max_mixed = ops.maximum(pd.Series([1.0, 5.0]), [2.0, 4.0])
     min_mixed = ops.minimum(pd.Series([1.0, 5.0]), [2.0, 4.0])
     np.testing.assert_allclose(_to_numpy(max_mixed), np.array([2.0, 5.0]))
     np.testing.assert_allclose(_to_numpy(min_mixed), np.array([1.0, 4.0]))
-    clipped = ops.clip(RaisingClipFrame([[1.0, 5.0], [2.0, 7.0]]), [1.5, 2.5], [4.0, 6.0])
-    np.testing.assert_allclose(_to_numpy(clipped), np.array([[1.5, 5.0], [2.0, 6.0]]))
+    clipped = ops.clip(
+        RaisingClipFrame([[1.0, 5.0], [2.0, 7.0]]), [1.5, 2.5], [4.0, 6.0]
+    )
+    np.testing.assert_allclose(
+        _to_numpy(clipped), np.array([[1.5, 5.0], [2.0, 6.0]])
+    )
 
     where_series = ops.where(
         pd.Series([True, False], index=["a", "b"]),
@@ -346,7 +421,9 @@ def test_pandas_backend_fallback_paths():
         _to_numpy(where_series), np.array([1.0, np.nan]), equal_nan=True
     )
     np.testing.assert_allclose(
-        ops.where(np.array([True, False]), np.array([1.0, 2.0]), np.array([3.0, 4.0])),
+        ops.where(
+            np.array([True, False]), np.array([1.0, 2.0]), np.array([3.0, 4.0])
+        ),
         np.array([1.0, 4.0]),
     )
 
@@ -358,7 +435,9 @@ def test_pandas_backend_fallback_paths():
     assert list(squeezed.index) == ["a", "b"]
 
     concat_mixed = ops.concat([pd.Series([1.0, 2.0]), [3.0, 4.0]], axis=0)
-    np.testing.assert_allclose(_to_numpy(concat_mixed), np.array([1.0, 2.0, 3.0, 4.0]))
+    np.testing.assert_allclose(
+        _to_numpy(concat_mixed), np.array([1.0, 2.0, 3.0, 4.0])
+    )
 
     casted = ops.astype(RaisingAstypeSeries([1.2, 2.8]), "int64")
     np.testing.assert_allclose(_to_numpy(casted), np.array([1, 2]))
@@ -398,18 +477,26 @@ def test_torch_backend_branch_cases():
     assert _to_numpy(b.max(arr)).item() == 5.0
     assert _to_numpy(b.min(arr)).item() == 1.0
     assert _to_numpy(b.argmax(arr)).item() == 1
-    np.testing.assert_allclose(_to_numpy(b.argmax(bool_arr, axis=1)), np.array([0, 1]))
+    np.testing.assert_allclose(
+        _to_numpy(b.argmax(bool_arr, axis=1)), np.array([0, 1])
+    )
     np.testing.assert_allclose(_to_numpy(b.arange(4)), np.array([0, 1, 2, 3]))
 
-    np.testing.assert_allclose(_to_numpy(b.asarray([[1, 2], [3, 4]])), np.array([[1, 2], [3, 4]]))
+    np.testing.assert_allclose(
+        _to_numpy(b.asarray([[1, 2], [3, 4]])), np.array([[1, 2], [3, 4]])
+    )
 
     pd = pytest.importorskip("pandas")
     np.testing.assert_allclose(
         _to_numpy(b.asarray(pd.DataFrame([[1, 2], [3, 4]]))),
         np.array([[1, 2], [3, 4]]),
     )
-    np.testing.assert_allclose(b.to_numpy(torch.tensor([1, 2])), np.array([1, 2]))
-    np.testing.assert_allclose(_to_numpy(b.to_numpy(pd.Series([1, 2]))), np.array([1, 2]))
+    np.testing.assert_allclose(
+        b.to_numpy(torch.tensor([1, 2])), np.array([1, 2])
+    )
+    np.testing.assert_allclose(
+        _to_numpy(b.to_numpy(pd.Series([1, 2]))), np.array([1, 2])
+    )
     np.testing.assert_allclose(b.to_numpy([1, 2, 3]), np.array([1, 2, 3]))
 
     with pytest.raises(TypeError):
@@ -425,8 +512,12 @@ def test_jax_backend_branch_cases():
 
     b = get_backend(jnp.asarray([1.0]))
     arr = b.asarray(pd.DataFrame([[3.0, 1.0], [2.0, 4.0]]))
-    np.testing.assert_allclose(_to_numpy(arr), np.array([[3.0, 1.0], [2.0, 4.0]]))
-    np.testing.assert_allclose(b.to_numpy(arr), np.array([[3.0, 1.0], [2.0, 4.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(arr), np.array([[3.0, 1.0], [2.0, 4.0]])
+    )
+    np.testing.assert_allclose(
+        b.to_numpy(arr), np.array([[3.0, 1.0], [2.0, 4.0]])
+    )
 
     desc = b.argsort(arr, axis=1, descending=True)
     np.testing.assert_allclose(_to_numpy(desc), np.array([[0, 1], [1, 0]]))
@@ -438,9 +529,15 @@ def test_tensorflow_backend_branch_cases():
 
     b = get_backend(tf.convert_to_tensor([1.0]))
     frame = pd.DataFrame([[1, 2], [3, 4]])
-    np.testing.assert_allclose(_to_numpy(b.asarray(frame)), np.array([[1, 2], [3, 4]]))
-    np.testing.assert_allclose(_to_numpy(b.asarray([[5, 6], [7, 8]])), np.array([[5, 6], [7, 8]]))
-    np.testing.assert_allclose(_to_numpy(b.to_numpy(frame)), np.array([[1, 2], [3, 4]]))
+    np.testing.assert_allclose(
+        _to_numpy(b.asarray(frame)), np.array([[1, 2], [3, 4]])
+    )
+    np.testing.assert_allclose(
+        _to_numpy(b.asarray([[5, 6], [7, 8]])), np.array([[5, 6], [7, 8]])
+    )
+    np.testing.assert_allclose(
+        _to_numpy(b.to_numpy(frame)), np.array([[1, 2], [3, 4]])
+    )
     np.testing.assert_allclose(b.to_numpy([1, 2, 3]), np.array([1, 2, 3]))
     np.testing.assert_allclose(_to_numpy(b.arange(4)), np.array([0, 1, 2, 3]))
 
@@ -494,16 +591,25 @@ def test_get_backend_shape_and_column_helpers_branches():
     tensor = tf.constant([[1.0, 2.0], [3.0, 4.0]])
     tc0, tc1 = split_columns(tensor, (0, 1), keepdims=True)
     np.testing.assert_allclose(_to_numpy(tc0), np.array([[1.0], [3.0]]))
-    np.testing.assert_allclose(_to_numpy(concat_columns([tc0, tc1], like=tensor)), np.array([[1.0, 2.0], [3.0, 4.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(concat_columns([tc0, tc1], like=tensor)),
+        np.array([[1.0, 2.0], [3.0, 4.0]]),
+    )
     tc0_nk, tc1_nk = split_columns(tensor, (0, 1), keepdims=False)
     np.testing.assert_allclose(_to_numpy(tc0_nk), np.array([1.0, 3.0]))
     np.testing.assert_allclose(_to_numpy(tc1_nk), np.array([2.0, 4.0]))
 
     torch_cols = [torch.tensor([[1.0], [2.0]]), torch.tensor([[3.0], [4.0]])]
-    np.testing.assert_allclose(_to_numpy(concat_columns(torch_cols, like=torch_cols[0])), np.array([[1.0, 3.0], [2.0, 4.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(concat_columns(torch_cols, like=torch_cols[0])),
+        np.array([[1.0, 3.0], [2.0, 4.0]]),
+    )
 
     jax_cols = [jnp.asarray([[1.0], [2.0]]), jnp.asarray([[3.0], [4.0]])]
-    np.testing.assert_allclose(_to_numpy(concat_columns(jax_cols, like=jax_cols[0])), np.array([[1.0, 3.0], [2.0, 4.0]]))
+    np.testing.assert_allclose(
+        _to_numpy(concat_columns(jax_cols, like=jax_cols[0])),
+        np.array([[1.0, 3.0], [2.0, 4.0]]),
+    )
 
 
 def test_is_jax_false_when_jax_numpy_missing(monkeypatch):
@@ -513,6 +619,27 @@ def test_is_jax_false_when_jax_numpy_missing(monkeypatch):
     monkeypatch.delitem(backend_module.sys.modules, "jax.numpy", raising=False)
 
     assert backend_module._is_jax(np.array([1.0])) is False
+
+
+def test_is_jax_fallback_uses_jnp_ndarray_when_jax_array_missing(monkeypatch):
+    import deel.puncc.api.backend as backend_module
+
+    class FakeJnpArray:
+        pass
+
+    class FakeJnpModule:
+        ndarray = FakeJnpArray
+
+    class FakeJaxModule:
+        pass
+
+    monkeypatch.setitem(backend_module.sys.modules, "jax", FakeJaxModule())
+    monkeypatch.setitem(
+        backend_module.sys.modules, "jax.numpy", FakeJnpModule()
+    )
+
+    assert backend_module._is_jax(FakeJnpArray()) is True
+    assert backend_module._is_jax(object()) is False
 
 
 def test_pandas_backend_forced_mix_and_take_along_axis_branches(monkeypatch):
@@ -534,10 +661,16 @@ def test_pandas_backend_forced_mix_and_take_along_axis_branches(monkeypatch):
 
     max_df = ops.maximum(frame, np.array([[2.0, 4.0], [1.0, 6.0]]))
     min_df = ops.minimum(frame, np.array([[2.0, 4.0], [1.0, 6.0]]))
-    np.testing.assert_allclose(_to_numpy(max_df), np.array([[2.0, 5.0], [2.0, 6.0]]))
-    np.testing.assert_allclose(_to_numpy(min_df), np.array([[1.0, 4.0], [1.0, 3.0]]))
     np.testing.assert_allclose(
-        ops.where(np.array([True, False]), np.array([1.0, 2.0]), np.array([3.0, 4.0])),
+        _to_numpy(max_df), np.array([[2.0, 5.0], [2.0, 6.0]])
+    )
+    np.testing.assert_allclose(
+        _to_numpy(min_df), np.array([[1.0, 4.0], [1.0, 3.0]])
+    )
+    np.testing.assert_allclose(
+        ops.where(
+            np.array([True, False]), np.array([1.0, 2.0]), np.array([3.0, 4.0])
+        ),
         np.array([1.0, 4.0]),
     )
 
@@ -546,7 +679,9 @@ def test_pandas_backend_forced_mix_and_take_along_axis_branches(monkeypatch):
         "take_along_axis",
         lambda arr, indices, axis: np.array([1.0, 2.0]),
     )
-    out_frame_1d = ops.take_along_axis(frame, pd.DataFrame([[0], [0]], index=frame.index), axis=1)
+    out_frame_1d = ops.take_along_axis(
+        frame, pd.DataFrame([[0], [0]], index=frame.index), axis=1
+    )
     assert isinstance(out_frame_1d, pd.Series)
     assert list(out_frame_1d.index) == ["a", "b"]
 
@@ -558,7 +693,9 @@ def test_pandas_backend_forced_mix_and_take_along_axis_branches(monkeypatch):
         "take_along_axis",
         lambda arr, indices, axis: np.array([[1.0], [2.0]]),
     )
-    out_series_as_df = ops.take_along_axis(series, pd.DataFrame([[0], [0]], index=series.index), axis=0)
+    out_series_as_df = ops.take_along_axis(
+        series, pd.DataFrame([[0], [0]], index=series.index), axis=0
+    )
     assert isinstance(out_series_as_df, pd.DataFrame)
     assert list(out_series_as_df.index) == ["a", "b"]
 
@@ -592,6 +729,7 @@ def test_pandas_backend_take_along_axis_returns_raw_output(monkeypatch):
     out = ops.take_along_axis(series, pd.Series([0, 0]), axis=0)
     assert np.array(out).shape == ()
 
+
 def test_copy_model_sklearn_preserves_fitted_state():
     linear_model = pytest.importorskip("sklearn.linear_model")
 
@@ -621,7 +759,9 @@ def test_copy_model_torch_preserves_parameters():
 
     assert infer_model_backend(model) == "torch"
     assert copied is not model
-    for original_param, copied_param in zip(model.parameters(), copied.parameters()):
+    for original_param, copied_param in zip(
+        model.parameters(), copied.parameters()
+    ):
         assert torch.allclose(original_param, copied_param)
 
     with torch.no_grad():
@@ -662,7 +802,9 @@ def test_copy_model_tensorflow_preserves_weights():
 
     assert infer_model_backend(model) == "tensorflow"
     assert copied is not model
-    for original_weights, copied_weights in zip(model.get_weights(), copied.get_weights()):
+    for original_weights, copied_weights in zip(
+        model.get_weights(), copied.get_weights()
+    ):
         np.testing.assert_allclose(copied_weights, original_weights)
 
     model.set_weights(
@@ -715,12 +857,12 @@ def test_prediction_import_does_not_eagerly_import_tensorflow():
 
     assert result.stdout.strip().splitlines()[-1] == "False"
 
+
 def test_is_jax_model_true_for_jax_array():
     jnp = pytest.importorskip("jax.numpy")
     import deel.puncc.api.backend as backend_module
 
     assert backend_module._is_jax_model(jnp.asarray([1.0])) is True
-
 
 
 def test_is_jax_model_false_without_loaded_jax(monkeypatch):
@@ -730,4 +872,3 @@ def test_is_jax_model_false_without_loaded_jax(monkeypatch):
     monkeypatch.delitem(backend_module.sys.modules, "jax.numpy", raising=False)
 
     assert backend_module._is_jax_model(object()) is False
-

--- a/tests/api/test_backend.py
+++ b/tests/api/test_backend.py
@@ -21,12 +21,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from pathlib import Path
+import subprocess
+import sys
+
 import numpy as np
 import pytest
 
 from deel.puncc.api.backend import concat_columns
+from deel.puncc.api.backend import copy_model
 from deel.puncc.api.backend import get_backend
 from deel.puncc.api.backend import infer_backend
+from deel.puncc.api.backend import infer_model_backend
 from deel.puncc.api.backend import shape2
 from deel.puncc.api.backend import split_columns
 
@@ -81,6 +87,13 @@ def test_infer_backend_pandas_and_mixed_error():
 
     with pytest.raises(TypeError):
         infer_backend(pd.Series([1, 2, 3]), np.array([1, 2, 3]))
+
+
+def test_infer_model_backend_generic_default():
+    class GenericModel:
+        pass
+
+    assert infer_model_backend(GenericModel()) == "generic"
 
 
 @pytest.mark.parametrize("name", ["numpy", "pandas", "torch", "tensorflow", "jax"])
@@ -578,3 +591,143 @@ def test_pandas_backend_take_along_axis_returns_raw_output(monkeypatch):
 
     out = ops.take_along_axis(series, pd.Series([0, 0]), axis=0)
     assert np.array(out).shape == ()
+
+def test_copy_model_sklearn_preserves_fitted_state():
+    linear_model = pytest.importorskip("sklearn.linear_model")
+
+    X = np.array([[0.0], [1.0], [2.0]])
+    y = np.array([0.0, 1.0, 2.0])
+    model = linear_model.LinearRegression().fit(X, y)
+
+    copied = copy_model(model)
+
+    assert infer_model_backend(model) == "sklearn"
+    assert copied is not model
+    np.testing.assert_allclose(copied.predict(X), model.predict(X))
+
+    model.coef_[0] += 1.0
+    assert not np.allclose(copied.coef_, model.coef_)
+
+
+def test_copy_model_torch_preserves_parameters():
+    torch = pytest.importorskip("torch")
+
+    model = torch.nn.Sequential(torch.nn.Linear(2, 1, bias=True))
+    with torch.no_grad():
+        model[0].weight.copy_(torch.tensor([[1.0, 2.0]]))
+        model[0].bias.copy_(torch.tensor([0.5]))
+
+    copied = copy_model(model)
+
+    assert infer_model_backend(model) == "torch"
+    assert copied is not model
+    for original_param, copied_param in zip(model.parameters(), copied.parameters()):
+        assert torch.allclose(original_param, copied_param)
+
+    with torch.no_grad():
+        model[0].weight.add_(1.0)
+    assert not torch.allclose(model[0].weight, copied[0].weight)
+
+
+def test_copy_model_tensorflow_unbuilt_model():
+    tf = pytest.importorskip("tensorflow")
+
+    model = tf.keras.Sequential()
+    model.add(tf.keras.layers.Dense(1))
+
+    copied = copy_model(model)
+
+    assert infer_model_backend(model) == "tensorflow"
+    assert copied is not model
+    assert copied.built is False
+
+
+def test_copy_model_tensorflow_preserves_weights():
+    tf = pytest.importorskip("tensorflow")
+
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Input(shape=(2,)),
+            tf.keras.layers.Dense(1, use_bias=True),
+        ]
+    )
+    model.set_weights(
+        [
+            np.array([[1.0], [2.0]], dtype=np.float32),
+            np.array([0.5], dtype=np.float32),
+        ]
+    )
+
+    copied = copy_model(model)
+
+    assert infer_model_backend(model) == "tensorflow"
+    assert copied is not model
+    for original_weights, copied_weights in zip(model.get_weights(), copied.get_weights()):
+        np.testing.assert_allclose(copied_weights, original_weights)
+
+    model.set_weights(
+        [
+            np.array([[3.0], [4.0]], dtype=np.float32),
+            np.array([1.5], dtype=np.float32),
+        ]
+    )
+    assert not np.allclose(model.get_weights()[0], copied.get_weights()[0])
+
+
+def test_copy_model_jax_preserves_pytree_values():
+    jnp = pytest.importorskip("jax.numpy")
+
+    model = {
+        "weights": jnp.asarray([[1.0, 2.0], [3.0, 4.0]]),
+        "bias": jnp.asarray([0.5, 1.5]),
+    }
+
+    copied = copy_model(model)
+
+    assert infer_model_backend(model) == "jax"
+    assert copied is not model
+    np.testing.assert_allclose(
+        _to_numpy(copied["weights"]), np.array([[1.0, 2.0], [3.0, 4.0]])
+    )
+    np.testing.assert_allclose(_to_numpy(copied["bias"]), np.array([0.5, 1.5]))
+
+    model["weights"] = model["weights"] + 1.0
+    np.testing.assert_allclose(
+        _to_numpy(copied["weights"]), np.array([[1.0, 2.0], [3.0, 4.0]])
+    )
+
+
+def test_prediction_import_does_not_eagerly_import_tensorflow():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = (
+        "import sys; "
+        "sys.modules.pop('tensorflow', None); "
+        "import deel.puncc.api.prediction; "
+        "print('tensorflow' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=True,
+        cwd=repo_root,
+        text=True,
+    )
+
+    assert result.stdout.strip().splitlines()[-1] == "False"
+
+def test_is_jax_model_true_for_jax_array():
+    jnp = pytest.importorskip("jax.numpy")
+    import deel.puncc.api.backend as backend_module
+
+    assert backend_module._is_jax_model(jnp.asarray([1.0])) is True
+
+
+
+def test_is_jax_model_false_without_loaded_jax(monkeypatch):
+    import deel.puncc.api.backend as backend_module
+
+    monkeypatch.delitem(backend_module.sys.modules, "jax", raising=False)
+    monkeypatch.delitem(backend_module.sys.modules, "jax.numpy", raising=False)
+
+    assert backend_module._is_jax_model(object()) is False
+

--- a/tests/api/test_experimental.py
+++ b/tests/api/test_experimental.py
@@ -37,6 +37,19 @@ class TinyNet(torch.nn.Module):
         return self.linear(x)
 
 
+class SequentialNet(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(2, 4),
+            torch.nn.ReLU(),
+            torch.nn.Linear(4, 1),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
 def test_torch_predictor_fit_updates_weights_and_predicts():
     torch.manual_seed(0)
     model = TinyNet(input_feat=2, output_feat=1)
@@ -110,3 +123,22 @@ def test_torch_predictor_fit_defaults_to_one_epoch():
     predictor.fit(x, y)
 
     assert not torch.allclose(model.linear.weight.detach(), weights_before)
+
+def test_torch_predictor_copy_supports_non_shape_constructor():
+    torch.manual_seed(0)
+    predictor = TorchPredictor(
+        model=SequentialNet(),
+        is_trained=True,
+        optimizer=torch.optim.SGD,
+        criterion=torch.nn.MSELoss(reduction="sum"),
+        lr=0.05,
+    )
+
+    predictor_copy = predictor.copy()
+
+    assert predictor_copy is not predictor
+    assert predictor_copy.model is not predictor.model
+
+    x = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    assert torch.allclose(predictor.model(x), predictor_copy.model(x))
+

--- a/tests/api/test_prediction_wrappers.py
+++ b/tests/api/test_prediction_wrappers.py
@@ -123,45 +123,34 @@ def test_dual_predictor_copy_and_meanvar_fit():
     assert sigma_fit_args[2] == {"epochs": 2}
 
 
-def test_dual_predictor_copy_runtime_error_branch(monkeypatch):
-    import deel.puncc.api.prediction as prediction_module
-
+def test_dual_predictor_copy_runtime_error_branch():
     class ReallyUncopyable:
         def __deepcopy__(self, memo):
             raise RuntimeError("no deepcopy")
 
     predictor = DualPredictor(models=[ReallyUncopyable(), ReallyUncopyable()])
 
-    class FailingClone:
-        @staticmethod
-        def clone_model(model):
-            raise RuntimeError("clone failed")
-
-    class FakeKeras:
-        models = FailingClone()
-
-    class FakeTf:
-        keras = FakeKeras()
-
-    monkeypatch.setattr(prediction_module.importlib.util, "find_spec", lambda name: object())
-    monkeypatch.setattr(prediction_module, "tf", FakeTf())
-
-    with pytest.raises(RuntimeError, match="Cannot copy models"):
+    with pytest.raises(RuntimeError, match="Cannot copy model with backend 'generic'"):
         predictor.copy()
 
 
-def test_dual_predictor_copy_re_raises_without_tensorflow(monkeypatch):
+def test_base_predictor_copy_uses_backend_copy_model(monkeypatch):
     import deel.puncc.api.prediction as prediction_module
 
-    class ReallyUncopyable:
-        def __deepcopy__(self, memo):
-            raise RuntimeError("no deepcopy")
+    expected_model = DummyModel(prediction=np.array([3.0, 4.0]))
+    copied_models = []
 
-    predictor = DualPredictor(models=[ReallyUncopyable(), ReallyUncopyable()])
-    monkeypatch.setattr(prediction_module.importlib.util, "find_spec", lambda name: None)
+    def fake_copy_model(model):
+        copied_models.append(model)
+        return expected_model
 
-    with pytest.raises(Exception, match="no deepcopy"):
-        predictor.copy()
+    monkeypatch.setattr(prediction_module, "copy_model", fake_copy_model)
+
+    predictor = BasePredictor(DummyModel(), is_trained=True)
+    copied = predictor.copy()
+
+    assert copied_models == [predictor.model]
+    assert copied.model is expected_model
 
 
 def test_base_predictor_copy_preserves_extra_attributes():

--- a/tests/test_regression_seed.py
+++ b/tests/test_regression_seed.py
@@ -53,6 +53,7 @@ RESULTS = {
     "lwcp": {"cov": 0.93, "width": 211.90},
     "lacp": {"cov": 0.96, "width": 347.87},
     "cqr": {"cov": 0.93, "width": 204.52},
+    "cqr_new_sklearn": {"cov": 0.94, "width": 204.624497},
     "cv+": {"cov": 0.9, "width": 232.55},
     "enbpi": {"cov": 0.9, "width": 221.5},
     "aenbpi": {"cov": 0.87, "width": 272.14},
@@ -65,7 +66,7 @@ RESULTS = {
 )
 def test_split_cp(diabetes_data, alpha, random_state):
     # Get data
-    (X_train, X_test, y_train, y_test) = diabetes_data
+    X_train, X_test, y_train, y_test = diabetes_data
     # split train data into fit and calibration
     X_fit, X_calib, y_fit, y_calib = train_test_split(
         X_train, y_train, random_state=random_state
@@ -103,7 +104,7 @@ def test_split_cp(diabetes_data, alpha, random_state):
 )
 def test_ne_split_cp(diabetes_data, alpha, random_state):
     # Get data
-    (X_train, X_test, y_train, y_test) = diabetes_data
+    X_train, X_test, y_train, y_test = diabetes_data
     # split train data into fit and calibration
     X_fit, X_calib, y_fit, y_calib = train_test_split(
         X_train, y_train, random_state=random_state
@@ -146,7 +147,7 @@ def test_ne_split_cp(diabetes_data, alpha, random_state):
 )
 def test_locally_adaptive_cp(diabetes_data, alpha, random_state):
     # Get data
-    (X_train, X_test, y_train, y_test) = diabetes_data
+    X_train, X_test, y_train, y_test = diabetes_data
     # split train data into fit and calibration
     X_fit, X_calib, y_fit, y_calib = train_test_split(
         X_train, y_train, random_state=random_state
@@ -187,7 +188,7 @@ def test_locally_adaptive_cp(diabetes_data, alpha, random_state):
 )
 def test_leverage_weighted_cp(diabetes_data, alpha, random_state):
     # Get data
-    (X_train, X_test, y_train, y_test) = diabetes_data
+    X_train, X_test, y_train, y_test = diabetes_data
     # split train data into fit and calibration
     X_fit, X_calib, y_fit, y_calib = train_test_split(
         X_train, y_train, random_state=random_state
@@ -226,7 +227,7 @@ def test_leverage_weighted_cp(diabetes_data, alpha, random_state):
 
 def test_leverage_weighted_cp_requires_x_fit(diabetes_data):
     # Get data
-    (X_train, _, y_train, _) = diabetes_data
+    X_train, _, y_train, _ = diabetes_data
     # split train data into fit and calibration
     _, X_calib, _, y_calib = train_test_split(X_train, y_train, random_state=42)
 
@@ -244,7 +245,7 @@ def test_leverage_weighted_cp_requires_x_fit(diabetes_data):
 )
 def test_cqr(diabetes_data, alpha, random_state):
     # Get data
-    (X_train, X_test, y_train, y_test) = diabetes_data
+    X_train, X_test, y_train, y_test = diabetes_data
     # split train data into fit and calibration
     X_fit, X_calib, y_fit, y_calib = train_test_split(
         X_train, y_train, random_state=random_state
@@ -281,11 +282,15 @@ def test_cqr(diabetes_data, alpha, random_state):
     width = regression_sharpness(
         y_pred_lower=y_pred_lower, y_pred_upper=y_pred_upper
     )
-    np.testing.assert_allclose(
-        [coverage, width],
-        [RESULTS["cqr"]["cov"], RESULTS["cqr"]["width"]],
-        rtol=0.0,
-        atol=5e-3,
+
+    assert any(
+        np.allclose(
+            [coverage, width],
+            [RESULTS[k]["cov"], RESULTS[k]["width"]],
+            rtol=0.0,
+            atol=5e-3,
+        )
+        for k in ("cqr", "cqr_new_sklearn")
     )
 
 
@@ -295,7 +300,7 @@ def test_cqr(diabetes_data, alpha, random_state):
 )
 def test_cv_plus(diabetes_data, alpha, random_state):
     # Get data
-    (X_train, X_test, y_train, y_test) = diabetes_data
+    X_train, X_test, y_train, y_test = diabetes_data
 
     # Create RF regression object and wrap it by a predictor
     rf_model = RandomForestRegressor(
@@ -328,7 +333,7 @@ def test_cv_plus(diabetes_data, alpha, random_state):
 )
 def test_enbpi(diabetes_data, alpha, random_state):
     # Get data
-    (X_train, X_test, y_train, y_test) = diabetes_data
+    X_train, X_test, y_train, y_test = diabetes_data
     # Create RF regression object and wrap it by a predictor
     rf_model = RandomForestRegressor(
         n_estimators=100, random_state=random_state
@@ -362,7 +367,7 @@ def test_enbpi(diabetes_data, alpha, random_state):
 )
 def test_adaptive_enbpi(diabetes_data, alpha, random_state):
     # Get data
-    (X_train, X_test, y_train, y_test) = diabetes_data
+    X_train, X_test, y_train, y_test = diabetes_data
     # Create mean and dispersion regressors
     mean_model = RandomForestRegressor(
         n_estimators=100, random_state=random_state

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310},py{38,39,310}-lint
+envlist = py{39,310},py{39,310}-lint
 
 [testenv]
 skipsdist = True
@@ -10,7 +10,7 @@ commands =
    pytest
 
 
-[testenv:py{38, 39, 310}-lint]
+[testenv:py{39, 310}-lint]
 skip_install = true
 commands =
    python -m pylint deel/puncc

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
    pytest
 
 
-[testenv:py{39, 310}-lint]
+[testenv:py{39,310}-lint]
 skip_install = true
 commands =
    python -m pylint deel/puncc


### PR DESCRIPTION
This PR moves model copying into the backend abstraction and removes framework-specific cloning logic from predictor wrappers.

### Added 
- Backend-level model copy abstraction supporting sklearn, JAX, TensorFlow/Keras, and PyTorch models through a unified `copy_model` entrypoint

### Changed
- Refactored predictor wrappers to delegate model cloning to the backend abstraction 
- Updated `TorchPredictor` experimental wrapper to reuse the shared backend copy mechanism
- Avoid eager import (e.g. tensorflow) from prediction wrappers by detecting loaded frameworks through runtime module inspection

### Fixed
- Improved framework-agnostic model copy compatibility across predictor wrappers
- Corrected the definition of the prediction set for RAPS in theory overview 

### CI / Maintenance
- Expanded API test coverage for backend-driven model copying and wrapper copy behavior
- Raised the minimum supported scikit-learn version to 1.5.0 to address security vulnerabilities in older releases.
- Added alternative expected seed results in conformal regression tests for newer scikit-learn versions.